### PR TITLE
Return and display multiple offsets, calculate number of records

### DIFF
--- a/api/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
@@ -95,7 +95,8 @@ public class TopicsResource {
                         Topic.Fields.INTERNAL,
                         Topic.Fields.PARTITIONS,
                         Topic.Fields.AUTHORIZED_OPERATIONS,
-                        Topic.Fields.CONFIGS
+                        Topic.Fields.CONFIGS,
+                        Topic.Fields.RECORD_COUNT
                     },
                     payload = ErrorCategory.InvalidQueryParameter.class)
             @Parameter(
@@ -110,7 +111,8 @@ public class TopicsResource {
                                 Topic.Fields.INTERNAL,
                                 Topic.Fields.PARTITIONS,
                                 Topic.Fields.AUTHORIZED_OPERATIONS,
-                                Topic.Fields.CONFIGS
+                                Topic.Fields.CONFIGS,
+                                Topic.Fields.RECORD_COUNT
                             }))
             List<String> fields,
 
@@ -165,7 +167,8 @@ public class TopicsResource {
                         Topic.Fields.INTERNAL,
                         Topic.Fields.PARTITIONS,
                         Topic.Fields.AUTHORIZED_OPERATIONS,
-                        Topic.Fields.CONFIGS
+                        Topic.Fields.CONFIGS,
+                        Topic.Fields.RECORD_COUNT
                     },
                     payload = ErrorCategory.InvalidQueryParameter.class)
             @Parameter(
@@ -180,7 +183,8 @@ public class TopicsResource {
                                 Topic.Fields.INTERNAL,
                                 Topic.Fields.PARTITIONS,
                                 Topic.Fields.AUTHORIZED_OPERATIONS,
-                                Topic.Fields.CONFIGS
+                                Topic.Fields.CONFIGS,
+                                Topic.Fields.RECORD_COUNT
                             }))
             List<String> fields,
 

--- a/api/src/main/java/com/github/eyefloaters/console/api/model/Either.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/model/Either.java
@@ -57,6 +57,10 @@ public class Either<P, A> {
         return primary.get();
     }
 
+    public Optional<P> getOptionalPrimary() {
+        return primary;
+    }
+
     public A getAlternate() {
         return alternate;
     }

--- a/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
@@ -206,11 +206,14 @@ public class TopicService {
     CompletableFuture<Void> maybeDescribeTopics(Admin adminClient, Map<Uuid, Topic> topics, List<String> fields, String offsetSpec) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
 
-        if (fields.contains(Topic.Fields.PARTITIONS) || fields.contains(Topic.Fields.AUTHORIZED_OPERATIONS)) {
+        if (fields.contains(Topic.Fields.PARTITIONS)
+                || fields.contains(Topic.Fields.AUTHORIZED_OPERATIONS)
+                || fields.contains(Topic.Fields.RECORD_COUNT)) {
             describeTopics(adminClient, topics.keySet(), fields, offsetSpec)
                 .thenApply(descriptions -> {
                     descriptions.forEach((name, either) -> {
-                        if (fields.contains(Topic.Fields.PARTITIONS)) {
+                        if (fields.contains(Topic.Fields.PARTITIONS)
+                                || fields.contains(Topic.Fields.RECORD_COUNT)) {
                             topics.get(name).addPartitions(either);
                         }
                         if (fields.contains(Topic.Fields.AUTHORIZED_OPERATIONS)) {

--- a/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -36,6 +37,9 @@ import com.github.eyefloaters.console.api.support.ListRequestContext;
 
 @ApplicationScoped
 public class TopicService {
+
+    private static final List<OffsetSpec> DEFAULT_OFFSET_SPECS =
+            List.of(OffsetSpec.earliest(), OffsetSpec.latest(), OffsetSpec.maxTimestamp());
 
     @Inject
     Supplier<Admin> clientSupplier;
@@ -264,40 +268,16 @@ public class TopicService {
     }
 
     CompletionStage<Void> listOffsets(Admin adminClient, Map<Uuid, Either<Topic, Throwable>> topics, String offsetSpec) {
-        OffsetSpec reqOffsetSpec = switch (offsetSpec) {
-            case KafkaOffsetSpec.EARLIEST -> OffsetSpec.earliest();
-            case KafkaOffsetSpec.LATEST -> OffsetSpec.latest();
-            case KafkaOffsetSpec.MAX_TIMESTAMP -> OffsetSpec.maxTimestamp();
-            default -> OffsetSpec.forTimestamp(Instant.parse(offsetSpec).toEpochMilli());
-        };
+        Map<String, Uuid> topicIds = new HashMap<>(topics.size());
 
-        Map<String, Uuid> topicIds = new HashMap<>();
-        Map<org.apache.kafka.common.TopicPartition, OffsetSpec> request = topics.entrySet().stream()
-                .filter(entry -> entry.getValue().isPrimaryPresent())
-                .map(entry -> {
-                    var topic = entry.getValue().getPrimary();
-                    topicIds.put(topic.getName(), entry.getKey());
-                    return topic;
-                })
-                .filter(topic -> topic.getPartitions().isPrimaryPresent())
-                .flatMap(topic -> topic.getPartitions().getPrimary()
-                        .stream()
-                        .map(partition -> new org.apache.kafka.common.TopicPartition(topic.getName(), partition.getPartition())))
-                .collect(Collectors.toMap(Function.identity(), ignored -> reqOffsetSpec));
-
-        var result = adminClient.listOffsets(request);
-        var pendingOffsets = request.keySet().stream()
-                .map(topicPartition -> result.partitionResult(topicPartition)
-                        .toCompletionStage()
-                        .<Void>handle((offsetResult, error) -> {
-                            addOffset(topics.get(topicIds.get(topicPartition.topic())).getPrimary(),
-                                        topicPartition.partition(),
-                                        offsetResult,
-                                        error);
-                            return null;
-                        }))
-                .map(CompletionStage::toCompletableFuture)
-                .toArray(CompletableFuture[]::new);
+        var pendingOffsets = getRequestOffsetSpecs(offsetSpec)
+                .stream()
+            .map(reqOffsetSpec -> getTopicPartitions(topics, topicIds)
+                .stream()
+                .collect(Collectors.toMap(Function.identity(), ignored -> reqOffsetSpec)))
+            .flatMap(request -> listOffsets(adminClient, topics, topicIds, request))
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new);
 
         var promise = new CompletableFuture<Void>();
 
@@ -308,13 +288,80 @@ public class TopicService {
         return promise;
     }
 
-    void addOffset(Topic topic, int partitionNo, ListOffsetsResultInfo result, Throwable error) {
+    List<OffsetSpec> getRequestOffsetSpecs(String offsetSpec) {
+        List<OffsetSpec> specs = new ArrayList<>(DEFAULT_OFFSET_SPECS);
+
+        // Never null, defaults to latest
+        switch (offsetSpec) { // NOSONAR
+            case KafkaOffsetSpec.EARLIEST, KafkaOffsetSpec.LATEST, KafkaOffsetSpec.MAX_TIMESTAMP:
+                break;
+            default:
+                specs.add(OffsetSpec.forTimestamp(Instant.parse(offsetSpec).toEpochMilli()));
+                break;
+        }
+
+        return specs;
+    }
+
+    List<org.apache.kafka.common.TopicPartition> getTopicPartitions(Map<Uuid, Either<Topic, Throwable>> topics, Map<String, Uuid> topicIds) {
+        return topics.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().isPrimaryPresent())
+                .map(entry -> {
+                    var topic = entry.getValue().getPrimary();
+                    topicIds.put(topic.getName(), entry.getKey());
+                    return topic;
+                })
+                .filter(topic -> topic.getPartitions().isPrimaryPresent())
+                .flatMap(topic -> topic.getPartitions().getPrimary()
+                        .stream()
+                        .map(partition -> new org.apache.kafka.common.TopicPartition(topic.getName(), partition.getPartition())))
+                .toList();
+    }
+
+    String getOffsetKey(OffsetSpec spec) {
+        if (spec instanceof OffsetSpec.EarliestSpec) {
+            return KafkaOffsetSpec.EARLIEST;
+        }
+        if (spec instanceof OffsetSpec.LatestSpec) {
+            return KafkaOffsetSpec.LATEST;
+        }
+        if (spec instanceof OffsetSpec.MaxTimestampSpec) {
+            return KafkaOffsetSpec.MAX_TIMESTAMP;
+        }
+        return "timestamp";
+    }
+
+    Stream<CompletionStage<Void>> listOffsets(
+            Admin adminClient,
+            Map<Uuid, Either<Topic, Throwable>> topics,
+            Map<String, Uuid> topicIds,
+            Map<org.apache.kafka.common.TopicPartition, OffsetSpec> request) {
+
+        var result = adminClient.listOffsets(request);
+
+        return request.entrySet()
+                .stream()
+                .map(entry -> result.partitionResult(entry.getKey())
+                        .toCompletionStage()
+                        .<Void>handle((offsetResult, error) -> {
+                            addOffset(topics.get(topicIds.get(entry.getKey().topic())).getPrimary(),
+                                        entry.getKey().partition(),
+                                        getOffsetKey(entry.getValue()),
+                                        offsetResult,
+                                        error);
+                            return null;
+                        }));
+
+    }
+
+    void addOffset(Topic topic, int partitionNo, String key, ListOffsetsResultInfo result, Throwable error) {
         topic.getPartitions()
             .getPrimary()
             .stream()
             .filter(partition -> partition.getPartition() == partitionNo)
             .findFirst()
-            .ifPresent(partition -> partition.addOffset(either(result, error)));
+            .ifPresent(partition -> partition.addOffset(key, either(result, error)));
     }
 
     Either<OffsetInfo, Throwable> either(ListOffsetsResultInfo result, Throwable error) {

--- a/api/src/test/java/com/github/eyefloaters/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/eyefloaters/console/api/TopicsResourceIT.java
@@ -69,7 +69,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -206,8 +205,8 @@ class TopicsResourceIT {
             .body("data.attributes", contains(aMapWithSize(2)))
             .body("data.attributes.name", contains(topicName))
             .body("data.attributes.partitions[0]", hasSize(2))
-            .body("data.attributes.partitions[0][0].offset.offset", is(2))
-            .body("data.attributes.partitions[0][0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.partitions[0][0].offsets.latest.offset", is(2))
+            .body("data.attributes.partitions[0][0].offsets.latest", not(hasKey("timestamp")));
     }
 
     @Test
@@ -227,8 +226,8 @@ class TopicsResourceIT {
             .body("data.attributes", contains(aMapWithSize(2)))
             .body("data.attributes.name", contains(topicName))
             .body("data.attributes.partitions[0]", hasSize(2))
-            .body("data.attributes.partitions[0][0].offset.offset", is(0))
-            .body("data.attributes.partitions[0][0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.partitions[0][0].offsets.earliest.offset", is(0))
+            .body("data.attributes.partitions[0][0].offsets.earliest", not(hasKey("timestamp")));
     }
 
     @Test
@@ -251,8 +250,8 @@ class TopicsResourceIT {
             .body("data.attributes", contains(aMapWithSize(2)))
             .body("data.attributes.name", contains(topicName))
             .body("data.attributes.partitions[0]", hasSize(2))
-            .body("data.attributes.partitions[0][0].offset.offset", is(0))
-            .body("data.attributes.partitions[0][0].offset.timestamp", is(first.toString()));
+            .body("data.attributes.partitions[0][0].offsets.timestamp.offset", is(0))
+            .body("data.attributes.partitions[0][0].offsets.timestamp.timestamp", is(first.toString()));
     }
 
     @Test
@@ -275,8 +274,8 @@ class TopicsResourceIT {
             .body("data.attributes", contains(aMapWithSize(2)))
             .body("data.attributes.name", contains(topicName))
             .body("data.attributes.partitions[0]", hasSize(2))
-            .body("data.attributes.partitions[0][0].offset.offset", is(1))
-            .body("data.attributes.partitions[0][0].offset.timestamp", is(second.toString()));
+            .body("data.attributes.partitions[0][0].offsets.maxTimestamp.offset", is(1))
+            .body("data.attributes.partitions[0][0].offsets.maxTimestamp.timestamp", is(second.toString()));
     }
 
     @ParameterizedTest
@@ -404,8 +403,8 @@ class TopicsResourceIT {
             .body("data.attributes.name", is(topicName))
             .body("data.attributes", not(hasKey("configs")))
             .body("data.attributes.partitions", hasSize(2))
-            .body("data.attributes.partitions[0].offset.offset", is(2))
-            .body("data.attributes.partitions[0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.partitions[0].offsets.latest.offset", is(2))
+            .body("data.attributes.partitions[0].offsets.latest", not(hasKey("timestamp")));
     }
 
     @Test
@@ -423,8 +422,8 @@ class TopicsResourceIT {
             .body("data.attributes.name", is(topicName))
             .body("data.attributes", not(hasKey("configs")))
             .body("data.attributes.partitions", hasSize(2))
-            .body("data.attributes.partitions[0].offset.offset", is(0))
-            .body("data.attributes.partitions[0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.partitions[0].offsets.earliest.offset", is(0))
+            .body("data.attributes.partitions[0].offsets.earliest", not(hasKey("timestamp")));
     }
 
     @Test
@@ -445,8 +444,8 @@ class TopicsResourceIT {
             .body("data.attributes.name", is(topicName))
             .body("data.attributes", not(hasKey("configs")))
             .body("data.attributes.partitions", hasSize(2))
-            .body("data.attributes.partitions[0].offset.offset", is(0))
-            .body("data.attributes.partitions[0].offset.timestamp", is(first.toString()));
+            .body("data.attributes.partitions[0].offsets.timestamp.offset", is(0))
+            .body("data.attributes.partitions[0].offsets.timestamp.timestamp", is(first.toString()));
     }
 
     @Test
@@ -467,8 +466,8 @@ class TopicsResourceIT {
             .body("data.attributes.name", is(topicName))
             .body("data.attributes", not(hasKey("configs")))
             .body("data.attributes.partitions", hasSize(2))
-            .body("data.attributes.partitions[0].offset.offset", is(1))
-            .body("data.attributes.partitions[0].offset.timestamp", is(second.toString()));
+            .body("data.attributes.partitions[0].offsets.maxTimestamp.offset", is(1))
+            .body("data.attributes.partitions[0].offsets.maxTimestamp.timestamp", is(second.toString()));
     }
 
     @Test
@@ -517,8 +516,8 @@ class TopicsResourceIT {
             .body("data.attributes.name", is(topicName))
             .body("data.attributes", not(hasKey("configs")))
             .body("data.attributes.partitions", hasSize(2))
-            .body("data.attributes.partitions[0].offset.meta.type", is("error"))
-            .body("data.attributes.partitions[0].offset.detail", is("EXPECTED TEST EXCEPTION"));
+            .body("data.attributes.partitions[0].offsets.latest.meta.type", is("error"))
+            .body("data.attributes.partitions[0].offsets.latest.detail", is("EXPECTED TEST EXCEPTION"));
     }
 
     @Test

--- a/api/src/test/java/com/github/eyefloaters/console/api/TopicsResourceIT.java
+++ b/api/src/test/java/com/github/eyefloaters/console/api/TopicsResourceIT.java
@@ -231,6 +231,24 @@ class TopicsResourceIT {
     }
 
     @Test
+    void testListTopicsWithRecordCountIncluded() {
+        String topicName = UUID.randomUUID().toString();
+        topicUtils.createTopics(clusterId1, List.of(topicName), 2);
+        topicUtils.produceRecord(topicName, 0, null, Collections.emptyMap(), "k1", "v1");
+        topicUtils.produceRecord(topicName, 0, null, Collections.emptyMap(), "k2", "v2");
+
+        whenRequesting(req -> req
+                .queryParam("fields[topics]", "name,recordCount")
+                .get("", clusterId1))
+            .assertThat()
+            .statusCode(is(Status.OK.getStatusCode()))
+            .body("data.size()", is(1))
+            .body("data.attributes", contains(aMapWithSize(2)))
+            .body("data.attributes.name", contains(topicName))
+            .body("data.attributes.recordCount", contains(2));
+    }
+
+    @Test
     void testListTopicsWithPartitionsIncludedAndOffsetWithTimestamp() {
         String topicName = UUID.randomUUID().toString();
         topicUtils.createTopics(clusterId1, List.of(topicName), 2);

--- a/ui/api/bookmarks.ts
+++ b/ui/api/bookmarks.ts
@@ -62,11 +62,16 @@ export async function createBookmark({
 
 export async function getClusters(): Promise<Cluster[]> {
   const url = `${process.env.BACKEND_URL}/api/kafkas?fields%5Bkafkas%5D=name,bootstrapServers,authType`;
-  const res = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-    },
-  });
-  const rawData = await res.json();
-  return Response.parse(rawData).data;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    const rawData = await res.json();
+    return Response.parse(rawData).data;
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
 }

--- a/ui/api/topics.ts
+++ b/ui/api/topics.ts
@@ -1,7 +1,7 @@
 import { Topic, TopicResponse, TopicsResponse } from "@/api/types";
 
 export async function getTopics(kafkaId: string): Promise<Topic[]> {
-  const url = `${process.env.BACKEND_URL}/api/kafkas/${kafkaId}/topics?fields%5Btopics%5D=name,internal,partitions,authorizedOperations,configs&offsetSpec=latest`;
+  const url = `${process.env.BACKEND_URL}/api/kafkas/${kafkaId}/topics?fields%5Btopics%5D=name,internal,partitions,authorizedOperations,configs`;
   const res = await fetch(url, {
     headers: {
       Accept: "application/json",
@@ -15,7 +15,7 @@ export async function getTopic(
   kafkaId: string,
   topicId: string,
 ): Promise<Topic> {
-  const url = `${process.env.BACKEND_URL}/api/kafkas/${kafkaId}/topics/${topicId}?fields%5Btopics%5D=name,internal,partitions,authorizedOperations,configs&offsetSpec=latest`;
+  const url = `${process.env.BACKEND_URL}/api/kafkas/${kafkaId}/topics/${topicId}?fields%5Btopics%5D=name,internal,partitions,authorizedOperations,configs`;
   const res = await fetch(url, {
     headers: {
       Accept: "application/json",

--- a/ui/api/types.ts
+++ b/ui/api/types.ts
@@ -24,6 +24,11 @@ export const BookmarkSchema = z.object({
   }),
 });
 export type Bookmark = z.infer<typeof BookmarkSchema>;
+const OffsetSchema = z.object({
+  offset: z.number().optional(),
+  timestamp: z.string().optional(),
+  leaderEpoch: z.number().optional(),
+});
 const PartitionSchema = z.object({
   partition: z.number(),
   leader: z.object({
@@ -45,10 +50,12 @@ const PartitionSchema = z.object({
       port: z.number(),
     }),
   ),
-  offset: z.object({
-    offset: z.number(),
-    leaderEpoch: z.number(),
-  }),
+  offsets: z.object({
+    earliest: OffsetSchema.optional(),
+    latest: OffsetSchema.optional(),
+    maxTimestamp: OffsetSchema.optional(),
+    timestamp: OffsetSchema.optional()
+  }).optional().nullable(),
 });
 const ConfigSchema = z.object({
   value: z.string(),

--- a/ui/api/types.ts
+++ b/ui/api/types.ts
@@ -56,6 +56,7 @@ const PartitionSchema = z.object({
     maxTimestamp: OffsetSchema.optional(),
     timestamp: OffsetSchema.optional()
   }).optional().nullable(),
+  recordCount: z.number().optional(),
 });
 const ConfigSchema = z.object({
   value: z.string(),
@@ -73,6 +74,7 @@ const TopicSchema = z.object({
     partitions: z.array(PartitionSchema),
     authorizedOperations: z.array(z.string()),
     configs: z.record(z.string(), ConfigSchema),
+    recordCount: z.number().optional(),
   }),
 });
 export const TopicsResponse = z.object({

--- a/ui/components/topicPage.tsx
+++ b/ui/components/topicPage.tsx
@@ -269,7 +269,7 @@ export function TopicDashboard({ topic }: { topic: Topic }) {
               case "recordCount":
                 return (
                   <Td key={key} dataLabel={"Record Count"}>
-                    {row.recordCount + '' || '-'}
+                    {row.recordCount ?? '-'}
                   </Td>
                 );
             }

--- a/ui/components/topicPage.tsx
+++ b/ui/components/topicPage.tsx
@@ -261,15 +261,15 @@ export function TopicDashboard({ topic }: { topic: Topic }) {
               case "offsets":
                 return (
                   <Td key={key} dataLabel={"Offset"}>
-                    {row.offsets?.earliest?.offset}
+                    {row.offsets?.earliest?.offset ?? '-'}
                     /
-                    {row.offsets?.latest?.offset}
+                    {row.offsets?.latest?.offset ?? '-'}
                   </Td>
                 );
               case "recordCount":
                 return (
                   <Td key={key} dataLabel={"Record Count"}>
-                    { (row.offsets?.latest?.offset ?? 0) - (row.offsets?.earliest?.offset ?? 0) }
+                    {row.recordCount + '' || '-'}
                   </Td>
                 );
             }

--- a/ui/components/topicPage.tsx
+++ b/ui/components/topicPage.tsx
@@ -191,7 +191,7 @@ export function TopicDashboard({ topic }: { topic: Topic }) {
           emptyStateNoData={<div>No partitions</div>}
           emptyStateNoResults={<div>todo</div>}
           ariaLabel={"Partitions"}
-          columns={["id", "leaderId", "replicas", "isr", "offset"] as const}
+          columns={["id", "leaderId", "replicas", "isr", "offsets", "recordCount"] as const}
           renderHeader={({ column, key, Th }) => {
             switch (column) {
               case "id":
@@ -218,10 +218,16 @@ export function TopicDashboard({ topic }: { topic: Topic }) {
                     In-Sync Replicas
                   </Th>
                 );
-              case "offset":
+              case "offsets":
                 return (
-                  <Th key={key} dataLabel={"Offset"}>
-                    Offset
+                  <Th key={key} dataLabel={"Offsets"}>
+                    Offsets (Earliest/Latest)
+                  </Th>
+                );
+              case "recordCount":
+                return (
+                  <Th key={key} dataLabel={"Record Count"}>
+                    Record Count
                   </Th>
                 );
             }
@@ -252,10 +258,18 @@ export function TopicDashboard({ topic }: { topic: Topic }) {
                     {row.isr.length}
                   </Td>
                 );
-              case "offset":
+              case "offsets":
                 return (
                   <Td key={key} dataLabel={"Offset"}>
-                    {row.offset.offset}
+                    {row.offsets?.earliest?.offset}
+                    /
+                    {row.offsets?.latest?.offset}
+                  </Td>
+                );
+              case "recordCount":
+                return (
+                  <Td key={key} dataLabel={"Record Count"}>
+                    { (row.offsets?.latest?.offset ?? 0) - (row.offsets?.earliest?.offset ?? 0) }
                   </Td>
                 );
             }


### PR DESCRIPTION
Sample response with all offsets included for the partition.
```json
{
  "data": {
    "id": "s0QDg0v1Q16m4QqQDvJEPQ",
    "type": "topics",
    "attributes": {
      "name": "__strimzi-topic-operator-kstreams-topic-store-changelog",
      "internal": false,
      "partitions": [
        {
          "partition": 0,
          "leader": {
            "id": 0,
            "host": "broker-0.cluster-a.192.168.39.252.nip.io",
            "port": 443
          },
          "replicas": [
            {
              "id": 0,
              "host": "broker-0.cluster-a.192.168.39.252.nip.io",
              "port": 443
            }
          ],
          "isr": [
            {
              "id": 0,
              "host": "broker-0.cluster-a.192.168.39.252.nip.io",
              "port": 443
            }
          ],
          "offsets": {
            "earliest": {
              "offset": 0,
              "leaderEpoch": 0
            },
            "latest": {
              "offset": 5,
              "leaderEpoch": 0
            },
            "maxTimestamp": {
              "offset": 4,
              "timestamp": "2023-09-07T18:02:17.546Z",
              "leaderEpoch": 0
            },
            "timestamp": {
              "offset": 0,
              "timestamp": "2023-08-23T10:56:53.639Z",
              "leaderEpoch": 0
            }
          }
        }
      ],
      "authorizedOperations": [
        "CREATE",
        "ALTER_CONFIGS",
        "DESCRIBE_CONFIGS",
        "ALTER",
        "DESCRIBE",
        "DELETE",
        "READ",
        "WRITE"
      ]
    }
  }
}
```
Display in the UI
![image](https://github.com/eyefloaters/console/assets/20868526/d5b8bf44-7db8-4bc4-8789-c46e2bb9e808)
