### PR TITLE
Display any defined number value

### DIFF
--- a/ui/components/Bytes.tsx
+++ b/ui/components/Bytes.tsx
@@ -2,5 +2,5 @@ import { useFormatBytes } from "@/utils/format";
 
 export function Bytes({ value }: { value: number | undefined }) {
   const formatter = useFormatBytes();
-  return value ? formatter(value) : "-";
+  return (typeof value !== 'undefined') ? formatter(value) : "-";
 }

--- a/ui/components/Bytes.tsx
+++ b/ui/components/Bytes.tsx
@@ -2,5 +2,5 @@ import { useFormatBytes } from "@/utils/format";
 
 export function Bytes({ value }: { value: number | undefined }) {
   const formatter = useFormatBytes();
-  return (typeof value !== 'undefined') ? formatter(value) : "-";
+  return (value !== undefined) ? formatter(value) : "-";
 }

--- a/ui/components/Number.tsx
+++ b/ui/components/Number.tsx
@@ -4,5 +4,5 @@ import { useFormatter } from "next-intl";
 
 export function Number({ value }: { value: number | undefined }) {
   const formatter = useFormatter();
-  return value ? formatter.number(value) : "-";
+  return (typeof value !== 'undefined') ? formatter.number(value) : "-";
 }

--- a/ui/components/Number.tsx
+++ b/ui/components/Number.tsx
@@ -4,5 +4,5 @@ import { useFormatter } from "next-intl";
 
 export function Number({ value }: { value: number | undefined }) {
   const formatter = useFormatter();
-  return (typeof value !== 'undefined') ? formatter.number(value) : "-";
+  return (value !== undefined) ? formatter.number(value) : "-";
 }


### PR DESCRIPTION
Several areas of the topic/partition page display dashes when there is a defined value 0.

Current:
<img width="1377" alt="image" src="https://github.com/eyefloaters/console/assets/966316/24dd6ebc-ffe8-4cca-bc76-5652b3a6cc96">
From https://github.com/eyefloaters/console/issues/60#issue-1933132684


This PR displays a defined number whenever one is present, like below:
![image](https://github.com/eyefloaters/console/assets/20868526/7d731fca-2ffd-4d4d-971e-e3e05df28847)
