### PR TITLE
Quality of life changes

### DIFF
--- a/ui/api/topics.ts
+++ b/ui/api/topics.ts
@@ -53,6 +53,7 @@ export async function getTopicMessages(
   topicId: string,
 ): Promise<MessageApiResponse> {
   const url = `${process.env.BACKEND_URL}/api/kafkas/${kafkaId}/topics/${topicId}/records?${consumeRecordsQuery}`;
+  log.debug({ url }, "Fetching topics");
   const res = await fetch(url, {
     headers: await getHeaders(),
     cache: "no-store",
@@ -60,6 +61,7 @@ export async function getTopicMessages(
   });
   const rawData = await res.json();
   const messages = (rawData?.data || []).map((r: any) => ({ ...r.attributes }));
+  log.trace({ messages, rawData }, "Got messages");
   return {
     lastUpdated: new Date(),
     messages,

--- a/ui/app/[locale]/kafka/[kafkaId]/(root)/KafkaBreadcrumbItem.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/(root)/KafkaBreadcrumbItem.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { ClusterDetail, KafkaResource } from "@/api/types";
+import { KafkaSwitcher } from "@/app/[locale]/kafka/[kafkaId]/KafkaSwitcher";
+import { useSelectedLayoutSegment } from "next/navigation";
+import { Suspense } from "react";
+
+export function KafkaBreadcrumbItem({
+  selected,
+  clusters,
+  isActive,
+}: {
+  selected: ClusterDetail;
+  clusters: KafkaResource[];
+  isActive: boolean;
+}) {
+  const segment = useSelectedLayoutSegment();
+
+  return (
+    <Suspense fallback={"Loading clusters..."}>
+      <KafkaSwitcher
+        selected={selected}
+        clusters={clusters}
+        isActive={isActive}
+        getSwitchHref={(kafkaId) => `/kafka/${kafkaId}/${segment}`}
+      />
+    </Suspense>
+  );
+}

--- a/ui/app/[locale]/kafka/[kafkaId]/(root)/brokers/BrokersTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/(root)/brokers/BrokersTable.tsx
@@ -22,7 +22,7 @@ export function BrokersTable({
       renderHeader={({ column, Th }) => {
         switch (column) {
           case "id":
-            return <Th width={15}>Id</Th>;
+            return <Th width={20}>Id</Th>;
           case "host":
             return <Th>Host</Th>;
           case "rack":

--- a/ui/app/[locale]/kafka/[kafkaId]/(root)/layout.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/(root)/layout.tsx
@@ -1,5 +1,6 @@
 import { getKafkaCluster } from "@/api/kafka";
 import { getResources } from "@/api/resources";
+import { getTopics } from "@/api/topics";
 import { KafkaParams } from "@/app/[locale]/kafka/[kafkaId]/kafka.params";
 import { BreadcrumbLink } from "@/components/BreadcrumbLink";
 import { Loading } from "@/components/Loading";
@@ -8,6 +9,7 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   Divider,
+  Label,
   Nav,
   NavList,
   PageBreadcrumb,
@@ -18,7 +20,7 @@ import {
 } from "@/libs/patternfly/react-core";
 import { notFound } from "next/navigation";
 import { PropsWithChildren, ReactNode, Suspense } from "react";
-import { KafkaSelectorBreadcrumbItem } from "./KafkaSelectorBreadcrumbItem";
+import { KafkaBreadcrumbItem } from "./KafkaBreadcrumbItem";
 
 export default async function KafkaLayout({
   children,
@@ -30,6 +32,7 @@ export default async function KafkaLayout({
     notFound();
   }
   const clusters = await getResources("kafka");
+  const topics = await getTopics(kafkaId);
 
   return (
     <>
@@ -37,14 +40,12 @@ export default async function KafkaLayout({
         <PageBreadcrumb>
           <Breadcrumb>
             <BreadcrumbLink href="/kafka">Kafka</BreadcrumbLink>
-            <BreadcrumbItem isActive={activeBreadcrumb === null}>
-              <Suspense fallback={"Loading clusters..."}>
-                <KafkaSelectorBreadcrumbItem
-                  selected={cluster}
-                  clusters={clusters}
-                  isActive={activeBreadcrumb === null}
-                />
-              </Suspense>
+            <BreadcrumbItem>
+              <KafkaBreadcrumbItem
+                selected={cluster}
+                clusters={clusters}
+                isActive={activeBreadcrumb === null}
+              />
             </BreadcrumbItem>
             {activeBreadcrumb && (
               <BreadcrumbItem>{activeBreadcrumb}</BreadcrumbItem>
@@ -61,18 +62,22 @@ export default async function KafkaLayout({
         <PageNavigation>
           <Nav aria-label="Group section navigation" variant="tertiary">
             <NavList>
-              {/*<NavItemLink url={`/kafka/${kafkaId}/overview`}>*/}
-              {/*  Overview*/}
-              {/*</NavItemLink>*/}
-              <NavItemLink url={`/kafka/${kafkaId}/brokers`}>
-                Brokers
-              </NavItemLink>
-              <NavItemLink url={`/kafka/${kafkaId}/topics`}>Topics</NavItemLink>
-              <NavItemLink url={`/kafka/${kafkaId}/schema-registry`}>
-                Schema registry
+              <NavItemLink url={`/kafka/${kafkaId}/topics`}>
+                Topics&nbsp;
+                <Label isCompact={true}>{topics.length}</Label>
               </NavItemLink>
               <NavItemLink url={`/kafka/${kafkaId}/consumer-groups`}>
-                Consumer groups
+                Consumer groups&nbsp;
+                <Label isCompact={true}>0</Label>
+              </NavItemLink>
+              <NavItemLink url={`/kafka/${kafkaId}/brokers`}>
+                Brokers&nbsp;
+                <Label isCompact={true}>
+                  {cluster.attributes.nodes.length}
+                </Label>
+              </NavItemLink>
+              <NavItemLink url={`/kafka/${kafkaId}/schema-registry`}>
+                Schema registry
               </NavItemLink>
             </NavList>
           </Nav>

--- a/ui/app/[locale]/kafka/[kafkaId]/KafkaSwitcher.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/KafkaSwitcher.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { ClusterDetail, KafkaResource } from "@/api/types";
 import {
   Divider,
@@ -9,19 +8,22 @@ import {
   MenuToggle,
   SearchInput,
 } from "@/libs/patternfly/react-core";
+import { Route } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { CSSProperties, useState } from "react";
 
-export const KafkaSelectorBreadcrumbItem = ({
+export function KafkaSwitcher<T extends string>({
   selected,
   clusters,
+  getSwitchHref,
   isActive = false,
 }: {
   selected: ClusterDetail;
   clusters: KafkaResource[];
+  getSwitchHref: (kafkaId: string) => Route<T> | URL;
   isActive?: boolean;
-}) => {
+}) {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [searchText, setSearchText] = useState<string>("");
@@ -88,7 +90,7 @@ export const KafkaSelectorBreadcrumbItem = ({
       )}
       onSelect={(_ev, value) => {
         if (typeof value === "string") {
-          router.push(`/kafka/${value}`);
+          router.push(getSwitchHref(value).toString());
         }
       }}
       selected={selected.id}
@@ -107,4 +109,4 @@ export const KafkaSelectorBreadcrumbItem = ({
       {menuItems}
     </Dropdown>
   );
-};
+}

--- a/ui/app/[locale]/kafka/[kafkaId]/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/page.tsx
@@ -7,5 +7,5 @@ export default async function KafkaRoot({ params }: { params: KafkaParams }) {
   if (!resource || !resource.attributes.cluster) {
     notFound();
   }
-  redirect(`${params.kafkaId}/brokers`);
+  redirect(`${params.kafkaId}/topics`);
 }

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/KafkaBreadcrumbItem.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/KafkaBreadcrumbItem.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { ClusterDetail, KafkaResource } from "@/api/types";
+import { KafkaSwitcher } from "@/app/[locale]/kafka/[kafkaId]/KafkaSwitcher";
+import { Suspense } from "react";
+
+export function KafkaBreadcrumbItem({
+  selected,
+  clusters,
+}: {
+  selected: ClusterDetail;
+  clusters: KafkaResource[];
+}) {
+  return (
+    <Suspense fallback={"Loading clusters..."}>
+      <KafkaSwitcher
+        selected={selected}
+        clusters={clusters}
+        isActive={false}
+        getSwitchHref={(kafkaId) => `/kafka/${kafkaId}/topics`}
+      />
+    </Suspense>
+  );
+}

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/layout.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/layout.tsx
@@ -1,10 +1,8 @@
 import { getKafkaCluster } from "@/api/kafka";
 import { getResources } from "@/api/resources";
 import { getTopic } from "@/api/topics";
-import { KafkaSelectorBreadcrumbItem } from "@/app/[locale]/kafka/[kafkaId]/(root)/KafkaSelectorBreadcrumbItem";
 import { KafkaTopicParams } from "@/app/[locale]/kafka/[kafkaId]/topics/kafkaTopic.params";
 import { BreadcrumbLink } from "@/components/BreadcrumbLink";
-import { Bytes } from "@/components/Bytes";
 import { Loading } from "@/components/Loading";
 import { NavItemLink } from "@/components/NavItemLink";
 import { Number } from "@/components/Number";
@@ -13,7 +11,6 @@ import {
   BreadcrumbItem,
   Divider,
   Label,
-  LabelGroup,
   Nav,
   NavList,
   PageBreadcrumb,
@@ -22,13 +19,9 @@ import {
   PageSection,
   Title,
 } from "@/libs/patternfly/react-core";
-import {
-  CodeBranchIcon,
-  HddIcon,
-  ListIcon,
-} from "@/libs/patternfly/react-icons";
 import { notFound } from "next/navigation";
 import { PropsWithChildren, Suspense } from "react";
+import { KafkaBreadcrumbItem } from "./KafkaBreadcrumbItem";
 
 export default async function KafkaLayout({
   children,
@@ -48,10 +41,7 @@ export default async function KafkaLayout({
           <Breadcrumb>
             <BreadcrumbLink href="/kafka">Kafka</BreadcrumbLink>
             <BreadcrumbItem>
-              <KafkaSelectorBreadcrumbItem
-                selected={cluster}
-                clusters={clusters}
-              />
+              <KafkaBreadcrumbItem selected={cluster} clusters={clusters} />
             </BreadcrumbItem>
             <BreadcrumbLink href={`/kafka/${kafkaId}/topics`}>
               Topics
@@ -69,36 +59,34 @@ export default async function KafkaLayout({
           <Title headingLevel={"h1"} className={"pf-v5-u-pb-sm"}>
             {topic.attributes.name}
           </Title>
-          <LabelGroup>
-            <Label color={"blue"} icon={<CodeBranchIcon />}>
-              <Number value={topic.attributes.partitions.length} />
-            </Label>
-            <Label color={"green"} icon={<ListIcon />}>
-              <Number value={topic.attributes.recordCount} />
-            </Label>
-            <Label color={"cyan"} icon={<HddIcon />}>
-              <Bytes value={topic.attributes.totalLeaderLogBytes} />
-            </Label>
-          </LabelGroup>
         </PageSection>
         <PageNavigation>
           <Nav aria-label="Group section navigation" variant="tertiary">
             <NavList>
-              <NavItemLink
-                url={`/kafka/${kafkaId}/topics/${topicId}/partitions`}
-              >
-                Partitions
-              </NavItemLink>
               <NavItemLink url={`/kafka/${kafkaId}/topics/${topicId}/messages`}>
-                Messages
-              </NavItemLink>
-              <NavItemLink url={`/kafka/${kafkaId}/topics/${topicId}/schema`}>
-                Schema
+                Messages&nbsp;
+                <Label isCompact={true}>
+                  <Number value={topic.attributes.recordCount} />
+                </Label>
               </NavItemLink>
               <NavItemLink
                 url={`/kafka/${kafkaId}/topics/${topicId}/consumer-groups`}
               >
-                Consumer groups
+                Consumer groups&nbsp;
+                <Label isCompact={true}>
+                  <Number value={0} />
+                </Label>
+              </NavItemLink>
+              <NavItemLink
+                url={`/kafka/${kafkaId}/topics/${topicId}/partitions`}
+              >
+                Partitions&nbsp;
+                <Label isCompact={true}>
+                  <Number value={topic.attributes.partitions.length} />
+                </Label>
+              </NavItemLink>
+              <NavItemLink url={`/kafka/${kafkaId}/topics/${topicId}/schema`}>
+                Schema
               </NavItemLink>
               <NavItemLink
                 url={`/kafka/${kafkaId}/topics/${topicId}/configuration`}

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/page.tsx
@@ -2,5 +2,5 @@ import { KafkaTopicParams } from "@/app/[locale]/kafka/[kafkaId]/topics/kafkaTop
 import { redirect } from "next/navigation";
 
 export default function TopicPage({ params }: { params: KafkaTopicParams }) {
-  redirect(`${params.topicId}/partitions`);
+  redirect(`${params.topicId}/messages`);
 }


### PR DESCRIPTION
Reordered tabs a bit, prioritising those that I feel are going the most commonly used ones by devs:
- Topics, when in a Cluster
- Messages, when in a Topic

For tabs that show a countable information I added a label with the count. This way you can enter a topic and see how many partitions it has without having to click the tab

The cluster switcher takes you to a different page depending on where you interacted with it:
- if inside one of the Cluster pages (Topics, Brokers, etc) it takes you to the same page for the new cluster
- if inside any other section, it will take you to the parent page. Eg. if you are browsing a specific topic, switching cluster will take you to the Topics page for that cluster

![image](https://github.com/eyefloaters/console/assets/966316/d9d4ab54-8ee5-4baa-987b-f7271a7632f1)
![image](https://github.com/eyefloaters/console/assets/966316/71146b24-3f38-468c-984c-54c41a45c99a)
