### PR TITLE
fix: use package-ecosystem `npm` for pnpm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   schedule:
     interval: weekly
 
-- package-ecosystem: "pnpm"
+- package-ecosystem: "npm"
   directory: "/ui"
   schedule:
     interval: weekly


### PR DESCRIPTION
As shown by https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#supported-repositories-and-ecosystems, pnpm should be using `npm` as the `package-ecosystem` for dependabot's configuration.