### PR TITLE
Truncate values in the messages list, retrieve up to 50k of data when checking a message details

### DIFF
--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/ConnectedMessagesTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/ConnectedMessagesTable.tsx
@@ -7,13 +7,15 @@ import { MessagesTable } from "./_components/MessagesTable";
 
 export function ConnectedMessagesTable({
   messages,
+  selectedMessage,
   partitions,
   params,
 }: {
   messages: Message[];
+  selectedMessage: Message | undefined;
   partitions: number;
   params: {
-    selectedOffset: number | undefined;
+    selected: string | undefined;
     partition: number | undefined;
     "filter[offset]": number | undefined;
     "filter[timestamp]": string | undefined;
@@ -91,7 +93,7 @@ export function ConnectedMessagesTable({
     startTransition(() => {
       updateUrl({
         ...params,
-        selectedOffset: message.attributes.offset,
+        selected: `${message.attributes.partition}:${message.attributes.offset}`,
       });
     });
   }
@@ -100,7 +102,7 @@ export function ConnectedMessagesTable({
     startTransition(() => {
       updateUrl({
         ...params,
-        selectedOffset: undefined,
+        selected: undefined,
       });
     });
   }
@@ -110,10 +112,6 @@ export function ConnectedMessagesTable({
       updateUrl({ ...params, _ts: Date.now() });
     });
   }
-
-  const selectedMessage = messages.find(
-    (m) => m.attributes.offset === params.selectedOffset,
-  );
 
   useEffect(() => {
     let interval: ReturnType<typeof setInterval>;

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
@@ -32,7 +32,7 @@ import { LimitSelector } from "./LimitSelector";
 import { MessageDetails, MessageDetailsProps } from "./MessageDetails";
 import { NoDataCell } from "./NoDataCell";
 import { UnknownValuePreview } from "./UnknownValuePreview";
-import { beautifyUnknownValue, isSameMessage } from "./utils";
+import { isSameMessage } from "./utils";
 
 const columns = [
   // "partition",
@@ -203,9 +203,8 @@ export function MessagesTable({
                         case "value":
                           return row.attributes.value ? (
                             <UnknownValuePreview
-                              value={beautifyUnknownValue(
-                                row.attributes.value || "",
-                              )}
+                              value={row.attributes.value}
+                              truncateAt={149}
                               onClick={() => {
                                 setDefaultTab("value");
                                 onSelectMessage(row);

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/parseSearchParams.ts
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/parseSearchParams.ts
@@ -3,7 +3,7 @@ import { stringToInt } from "@/utils/stringToInt";
 export type MessagesSearchParams = {
   limit: string | undefined;
   partition: string | undefined;
-  selectedOffset: string | undefined;
+  selected: string | undefined;
   "filter[offset]": string | undefined;
   "filter[timestamp]": string | undefined;
   "filter[epoch]": string | undefined;
@@ -14,7 +14,7 @@ export function parseSearchParams(searchParams: MessagesSearchParams) {
   const offset = stringToInt(searchParams["filter[offset]"]);
   const ts = stringToInt(searchParams["filter[timestamp]"]);
   const epoch = stringToInt(searchParams["filter[epoch]"]);
-  const selectedOffset = stringToInt(searchParams.selectedOffset);
+  const selected = searchParams.selected;
   const partition = stringToInt(searchParams.partition);
 
   const timeFilter = epoch ? epoch * 1000 : ts;
@@ -27,5 +27,18 @@ export function parseSearchParams(searchParams: MessagesSearchParams) {
     ? { type: "timestamp" as const, value: timestamp }
     : undefined;
 
-  return { limit, offset, timestamp, epoch, selectedOffset, partition, filter };
+  const [selectedPartition, selectedOffset] = selected
+    ? decodeURIComponent(selected).split(":").map(stringToInt)
+    : [undefined, undefined];
+
+  return {
+    limit,
+    offset,
+    timestamp,
+    epoch,
+    selectedOffset,
+    selectedPartition,
+    partition,
+    filter,
+  };
 }


### PR DESCRIPTION
This also makes the details drawer persistent, so the URL should be safer to share with others.
<img width="1488" alt="image" src="https://github.com/eyefloaters/console/assets/966316/65db721f-bae1-47c4-8b48-4401cef5fa91">
In the screen a message with a lot of data, scrolled down a bit.