### PR TITLE
Add filters to listTopics for `id`, `name`, and `visibility`

### DIFF
--- a/api/src/main/java/com/github/eyefloaters/console/api/Annotations.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/Annotations.java
@@ -15,11 +15,6 @@ public enum Annotations {
         this.value = NAMESPACE + '/' + name;
     }
 
-    @Override
-    public String toString() {
-        return value();
-    }
-
     public String value() {
         return value;
     }

--- a/api/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
@@ -40,6 +40,7 @@ import com.github.eyefloaters.console.api.model.ConsumerGroup;
 import com.github.eyefloaters.console.api.model.ListFetchParams;
 import com.github.eyefloaters.console.api.model.NewTopic;
 import com.github.eyefloaters.console.api.model.Topic;
+import com.github.eyefloaters.console.api.model.TopicFilterParams;
 import com.github.eyefloaters.console.api.model.TopicPatch;
 import com.github.eyefloaters.console.api.service.ConsumerGroupService;
 import com.github.eyefloaters.console.api.service.TopicService;
@@ -148,7 +149,7 @@ public class TopicsResource {
                     source = Topic.FIELDS_PARAM,
                     allowedValues = {
                         Topic.Fields.NAME,
-                        Topic.Fields.INTERNAL,
+                        Topic.Fields.VISIBILITY,
                         Topic.Fields.PARTITIONS,
                         Topic.Fields.AUTHORIZED_OPERATIONS,
                         Topic.Fields.CONFIGS,
@@ -165,7 +166,7 @@ public class TopicsResource {
                             implementation = String.class,
                             enumeration = {
                                 Topic.Fields.NAME,
-                                Topic.Fields.INTERNAL,
+                                Topic.Fields.VISIBILITY,
                                 Topic.Fields.PARTITIONS,
                                 Topic.Fields.AUTHORIZED_OPERATIONS,
                                 Topic.Fields.CONFIGS,
@@ -190,10 +191,20 @@ public class TopicsResource {
 
             @BeanParam
             @Valid
-            ListFetchParams listParams) {
+            ListFetchParams listParams,
+
+            @BeanParam
+            @Valid
+            TopicFilterParams filters) {
 
         requestedFields.accept(fields);
-        ListRequestContext<Topic> listSupport = new ListRequestContext<>(Topic.Fields.COMPARATOR_BUILDER, uriInfo.getRequestUri(), listParams, Topic::fromCursor);
+
+        ListRequestContext<Topic> listSupport = new ListRequestContext<>(
+                filters.buildPredicates(),
+                Topic.Fields.COMPARATOR_BUILDER,
+                uriInfo.getRequestUri(),
+                listParams,
+                Topic::fromCursor);
 
         return topicService.listTopics(fields, offsetSpec, listSupport)
                 .thenApply(topics -> new Topic.ListResponse(topics, listSupport))
@@ -224,7 +235,7 @@ public class TopicsResource {
                     source = Topic.FIELDS_PARAM,
                     allowedValues = {
                         Topic.Fields.NAME,
-                        Topic.Fields.INTERNAL,
+                        Topic.Fields.VISIBILITY,
                         Topic.Fields.PARTITIONS,
                         Topic.Fields.AUTHORIZED_OPERATIONS,
                         Topic.Fields.CONFIGS,
@@ -241,7 +252,7 @@ public class TopicsResource {
                             implementation = String.class,
                             enumeration = {
                                 Topic.Fields.NAME,
-                                Topic.Fields.INTERNAL,
+                                Topic.Fields.VISIBILITY,
                                 Topic.Fields.PARTITIONS,
                                 Topic.Fields.AUTHORIZED_OPERATIONS,
                                 Topic.Fields.CONFIGS,

--- a/api/src/main/java/com/github/eyefloaters/console/api/model/TopicFilterParams.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/model/TopicFilterParams.java
@@ -1,0 +1,95 @@
+package com.github.eyefloaters.console.api.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.QueryParam;
+
+import org.eclipse.microprofile.openapi.annotations.enums.Explode;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+
+import com.github.eyefloaters.console.api.support.ErrorCategory;
+import com.github.eyefloaters.console.api.support.FetchFilterPredicate;
+
+import io.xlate.validation.constraints.Expression;
+
+public class TopicFilterParams {
+
+    @QueryParam("filter[id]")
+    @Parameter(
+        description = "Retrieve only topics with an ID matching this parameter",
+        schema = @Schema(implementation = String[].class, minItems = 2),
+        explode = Explode.FALSE)
+    @Expression(
+        when = "self != null",
+        value = "self.operator == 'eq' || self.operator == 'in'",
+        message = "unsupported filter operator, supported values: [ 'eq', 'in' ]",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[id]")
+    @Expression(
+        when = "self != null",
+        value = "self.operands.size() >= 1",
+        message = "at least 1 operand is required",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[id]")
+    FetchFilter idFilter;
+
+    @QueryParam("filter[name]")
+    @Parameter(
+        description = "Retrieve only topics with a name matching this parameter",
+        schema = @Schema(implementation = String[].class, minItems = 2),
+        explode = Explode.FALSE)
+    @Expression(
+        when = "self != null",
+        value = "self.operator == 'eq' || self.operator == 'in' || self.operator == 'like'",
+        message = "unsupported filter operator, supported values: [ 'eq', 'in', 'like' ]",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[name]")
+    @Expression(
+        when = "self != null",
+        value = "self.operands.size() >= 1",
+        message = "at least 1 operand is required",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[name]")
+    FetchFilter nameFilter;
+
+    @QueryParam("filter[visibility]")
+    @DefaultValue("eq,external")
+    @Parameter(
+        description = "Retrieve only topics matching the visibility identified by this parameter",
+        schema = @Schema(implementation = String[].class, minItems = 2),
+        explode = Explode.FALSE)
+    @Expression(
+        when = "self != null",
+        value = "self.operator == 'eq' || self.operator == 'in'",
+        message = "unsupported filter operator, supported values: [ 'eq', 'in' ]",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[visibility]")
+    @Expression(
+        when = "self != null",
+        value = "self.operands.size() >= 1",
+        message = "at least 1 operand is required",
+        payload = ErrorCategory.InvalidQueryParameter.class,
+        node = "filter[visibility]")
+    FetchFilter visibilityFilter;
+
+    public List<Predicate<Topic>> buildPredicates() {
+        List<Predicate<Topic>> predicates = new ArrayList<>(3);
+
+        predicates.add(new FetchFilterPredicate<>(visibilityFilter, Topic::visibility));
+
+        if (nameFilter != null) {
+            predicates.add(new FetchFilterPredicate<>(nameFilter, Topic::name));
+        }
+
+        if (idFilter != null) {
+            predicates.add(new FetchFilterPredicate<>(idFilter, Topic::getId));
+        }
+
+        return predicates;
+    }
+
+}

--- a/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
@@ -142,10 +142,11 @@ public class TopicService {
 
         Admin adminClient = clientSupplier.get();
 
-        return listTopics(adminClient, false)
+        return listTopics(adminClient, true)
             .thenApply(list -> list.stream().map(Topic::fromTopicListing).toList())
             .thenComposeAsync(list -> augmentList(adminClient, list, fetchList, offsetSpec), threadContext.currentContextExecutor())
             .thenApply(list -> list.stream()
+                    .filter(listSupport)
                     .map(listSupport::tally)
                     .filter(listSupport::betweenCursors)
                     .sorted(listSupport.getSortComparator())

--- a/api/src/main/java/com/github/eyefloaters/console/api/support/FetchFilterPredicate.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/support/FetchFilterPredicate.java
@@ -1,0 +1,74 @@
+package com.github.eyefloaters.console.api.support;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import com.github.eyefloaters.console.api.model.FetchFilter;
+
+public class FetchFilterPredicate<B, F> implements Predicate<B> {
+
+    private final String operator;
+    private final List<F> operands;
+    private final Function<B, F> fieldSource;
+    private final Pattern likePattern;
+
+    public FetchFilterPredicate(FetchFilter filter, Function<String, F> operandParser, Function<B, F> fieldSource) {
+        this.operator = filter.getOperator();
+        this.operands = filter.getOperands().stream().map(operandParser).toList();
+        this.fieldSource = fieldSource;
+
+        if (operator.equals("like")) {
+            // throws ClassCastException if this class is constructed with an incorrect operandParser (API bug)
+            String firstOperand = (String) firstOperand();
+            likePattern = Pattern.compile(firstOperand
+                .replace(".", "\\.")
+                .replace("*", ".*")
+                .replace("?", "."));
+        } else {
+            likePattern = null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public FetchFilterPredicate(FetchFilter filter, Function<B, F> fieldSource) {
+        this(filter, op -> (F) op, fieldSource);
+    }
+
+    private F firstOperand() {
+        return operands.get(0);
+    }
+
+    @Override
+    public boolean test(B bean) {
+        F field = fieldSource.apply(bean);
+
+        switch (operator) {
+            case "in":
+                return operands.contains(field);
+
+            case "gte": {
+                @SuppressWarnings("unchecked")
+                // throws ClassCastException if this class is constructed with an incorrect operandParser (API bug)
+                Comparable<F> firstOperand = (Comparable<F>) firstOperand();
+                return firstOperand.compareTo(field) <= 0;
+            }
+
+            case "like": {
+                // throws ClassCastException if this class is constructed with an incorrect fieldSource (API bug)
+                return likePattern.matcher((String) field).matches();
+            }
+
+            case "eq":
+                return firstOperand().equals(field);
+
+            default:
+                /*
+                 * Exclude the record. This case should never be executed if proper input
+                 * validation is present for each filter parameter.
+                 */
+                return false;
+        }
+    }
+}

--- a/ui/api/topics/actions.ts
+++ b/ui/api/topics/actions.ts
@@ -32,7 +32,7 @@ export async function getTopics(
   const sp = new URLSearchParams(
     filterUndefinedFromObj({
       "fields[topics]":
-        "name,internal,partitions,recordCount,totalLeaderLogBytes,consumerGroups",
+        "name,visibility,partitions,recordCount,totalLeaderLogBytes,consumerGroups",
       "page[size]": params.pageSize,
       "page[after]": params.pageCursor,
       sort: params.sort

--- a/ui/api/topics/schema.ts
+++ b/ui/api/topics/schema.ts
@@ -2,7 +2,7 @@ import { ApiError } from "@/api/api";
 import { z } from "zod";
 
 export const describeTopicsQuery = encodeURI(
-  "fields[topics]=,name,internal,partitions,authorizedOperations,configs,recordCount,totalLeaderLogBytes,consumerGroups",
+  "fields[topics]=name,visibility,partitions,authorizedOperations,configs,recordCount,totalLeaderLogBytes,consumerGroups",
 );
 const OffsetSchema = z.object({
   offset: z.number().optional(),
@@ -59,7 +59,7 @@ const TopicSchema = z.object({
   type: z.literal("topics"),
   attributes: z.object({
     name: z.string(),
-    internal: z.boolean(),
+    visibility: z.string(),
     partitions: z.array(PartitionSchema),
     authorizedOperations: z.array(z.string()),
     configs: ConfigMapSchema,
@@ -86,7 +86,7 @@ const TopicListSchema = z.object({
   }),
   attributes: TopicSchema.shape.attributes.pick({
     name: true,
-    internal: true,
+    visibility: true,
     partitions: true,
     recordCount: true,
     totalLeaderLogBytes: true,


### PR DESCRIPTION
Closes #37 

Adds support for filtering topics by `id`, `name`, and `visibility`. "Internal" topics (those starting with `_`) are hidden by default any may be un-hidden by using `filter[visibility]=eq,internal` or `filter[visibility]=in,internal,external`.

Topic name filter supports `eq`, `in`, or `like` operations where `like` follows the Unix glob patterns. `*` allows any character, zero or more times; and `?` allows any single character.