### PR TITLE
Align the topics page to the designs

### DIFF
--- a/ui/api/topics/actions.ts
+++ b/ui/api/topics/actions.ts
@@ -23,7 +23,8 @@ const log = logger.child({ module: "topics-api" });
 export async function getTopics(
   kafkaId: string,
   params: {
-    search?: string;
+    name?: string;
+    id?: string;
     pageSize?: number;
     pageCursor?: string;
     sort?: string;
@@ -35,7 +36,8 @@ export async function getTopics(
     filterUndefinedFromObj({
       "fields[topics]":
         "name,visibility,partitions,recordCount,totalLeaderLogBytes,consumerGroups",
-      "filter[name]": params.search ? `like,*${params.search}*` : undefined,
+      "filter[id]": params.id ? `eq,${params.id}` : undefined,
+      "filter[name]": params.name ? `like,*${params.name}*` : undefined,
       "filter[visibility]": params.includeHidden
         ? "in,external,internal"
         : "eq,external",

--- a/ui/api/topics/actions.ts
+++ b/ui/api/topics/actions.ts
@@ -23,16 +23,22 @@ const log = logger.child({ module: "topics-api" });
 export async function getTopics(
   kafkaId: string,
   params: {
+    search?: string;
     pageSize?: number;
     pageCursor?: string;
     sort?: string;
     sortDir?: string;
+    includeHidden?: boolean;
   },
 ): Promise<TopicsResponse> {
   const sp = new URLSearchParams(
     filterUndefinedFromObj({
       "fields[topics]":
         "name,visibility,partitions,recordCount,totalLeaderLogBytes,consumerGroups",
+      "filter[name]": params.search ? `like,*${params.search}*` : undefined,
+      "filter[visibility]": params.includeHidden
+        ? "in,external,internal"
+        : "eq,external",
       "page[size]": params.pageSize,
       "page[after]": params.pageCursor,
       sort: params.sort
@@ -50,7 +56,7 @@ export async function getTopics(
   });
   log.debug({ url }, "getTopics");
   const rawData = await res.json();
-  log.trace({ url, rawData }, "getTopics response");
+  log.debug({ url, rawData }, "getTopics response");
   return TopicsResponseSchema.parse(rawData);
 }
 
@@ -102,7 +108,7 @@ export async function createTopic(
   const rawData = await res.json();
   log.debug({ url, rawData }, "createTopic response");
   const response = TopicCreateResponseSchema.parse(rawData);
-  log.trace(response, "createTopic response parsed");
+  log.debug(response, "createTopic response parsed");
   if (validateOnly === false) {
     revalidateTag("topics");
   }
@@ -134,7 +140,7 @@ export async function updateTopic(
     method: "PATCH",
     body: JSON.stringify(body),
   });
-  log.trace({ status: res.status }, "updateTopic response");
+  log.debug({ status: res.status }, "updateTopic response");
   try {
     if (res.status === 204) {
       revalidateTag(`topic-${topicId}`);

--- a/ui/api/topics/schema.ts
+++ b/ui/api/topics/schema.ts
@@ -102,7 +102,7 @@ export const TopicsResponseSchema = z.object({
   meta: z.object({
     page: z.object({
       total: z.number(),
-      pageNumber: z.number(),
+      pageNumber: z.number().optional(),
     }),
   }),
   links: z.object({

--- a/ui/app/[locale]/kafka/[kafkaId]/@header/topics/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/@header/topics/page.tsx
@@ -9,7 +9,10 @@ import {
   SplitItem,
   Tooltip,
 } from "@/libs/patternfly/react-core";
-import { OkIcon, WarningTriangleIcon } from "@/libs/patternfly/react-icons";
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from "@/libs/patternfly/react-icons";
 import { Suspense } from "react";
 
 export default function TopicsHeader({ params }: { params: KafkaParams }) {
@@ -55,7 +58,13 @@ function Header({
           <SplitItem>
             <Tooltip content={"Number of topics in sync"}>
               <Label
-                icon={ok === undefined ? <Spinner size={"sm"} /> : <OkIcon />}
+                icon={
+                  ok === undefined ? (
+                    <Spinner size={"sm"} />
+                  ) : (
+                    <CheckCircleIcon />
+                  )
+                }
                 color={"cyan"}
               >
                 {ok !== undefined && <Number value={ok} />}
@@ -69,7 +78,7 @@ function Header({
                   warning === undefined ? (
                     <Spinner size={"sm"} />
                   ) : (
-                    <WarningTriangleIcon />
+                    <ExclamationTriangleIcon />
                   )
                 }
                 color={"orange"}

--- a/ui/app/[locale]/kafka/[kafkaId]/@header/topics/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/@header/topics/page.tsx
@@ -1,4 +1,85 @@
-import { KafkaHeader } from "@/app/[locale]/kafka/[kafkaId]/@header/KafkaHeader";
+import { getTopics } from "@/api/topics/actions";
+import { KafkaParams } from "@/app/[locale]/kafka/[kafkaId]/kafka.params";
+import { AppHeader } from "@/components/AppHeader";
+import { Number } from "@/components/Number";
+import {
+  Label,
+  Spinner,
+  Split,
+  SplitItem,
+  Tooltip,
+} from "@/libs/patternfly/react-core";
+import { OkIcon, WarningTriangleIcon } from "@/libs/patternfly/react-icons";
+import { Suspense } from "react";
 
-export { fetchCache } from "@/app/[locale]/kafka/[kafkaId]/@header/KafkaHeader";
-export default KafkaHeader;
+export default function TopicsHeader({ params }: { params: KafkaParams }) {
+  return (
+    <Suspense fallback={<Header />}>
+      <ConnectedHeader params={params} />
+    </Suspense>
+  );
+}
+
+async function ConnectedHeader({ params }: { params: KafkaParams }) {
+  const topics = await getTopics(params.kafkaId, {});
+  return (
+    <Header
+      total={topics.meta.page.total}
+      ok={topics.meta.page.total}
+      warning={0}
+    />
+  );
+}
+
+function Header({
+  total,
+  ok,
+  warning,
+}: {
+  total?: number;
+  ok?: number;
+  warning?: number;
+}) {
+  return (
+    <AppHeader
+      title={
+        <Split hasGutter={true}>
+          <SplitItem>Topics</SplitItem>
+          <SplitItem>
+            <Label
+              icon={total === undefined ? <Spinner size={"sm"} /> : undefined}
+            >
+              {total !== undefined && <Number value={total} />}&nbsp;total
+            </Label>
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content={"Number of topics in sync"}>
+              <Label
+                icon={ok === undefined ? <Spinner size={"sm"} /> : <OkIcon />}
+                color={"cyan"}
+              >
+                {ok !== undefined && <Number value={ok} />}
+              </Label>
+            </Tooltip>
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content={"Number of topics under replicated"}>
+              <Label
+                icon={
+                  warning === undefined ? (
+                    <Spinner size={"sm"} />
+                  ) : (
+                    <WarningTriangleIcon />
+                  )
+                }
+                color={"orange"}
+              >
+                {warning !== undefined && <Number value={warning} />}
+              </Label>
+            </Tooltip>
+          </SplitItem>
+        </Split>
+      }
+    />
+  );
+}

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/EmptyStateNoTopics.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/EmptyStateNoTopics.tsx
@@ -1,6 +1,4 @@
-"use client";
 import { ButtonLink } from "@/components/ButtonLink";
-import { useHelp } from "@/components/Quickstarts/HelpContainer";
 import {
   EmptyState,
   EmptyStateActions,
@@ -12,7 +10,6 @@ import {
 import { PlusCircleIcon } from "@patternfly/react-icons";
 
 export function EmptyStateNoTopics({ createHref }: { createHref: string }) {
-  const openHelp = useHelp();
   return (
     <EmptyState>
       <EmptyStateHeader
@@ -20,16 +17,7 @@ export function EmptyStateNoTopics({ createHref }: { createHref: string }) {
         headingLevel="h4"
         icon={<EmptyStateIcon icon={PlusCircleIcon} />}
       />
-      <EmptyStateBody>
-        For help getting started, access the{" "}
-        <a
-          onClick={() => {
-            openHelp("connect-to-cluster"); // TODO: change this
-          }}
-        >
-          quick start guide
-        </a>
-      </EmptyStateBody>
+      <EmptyStateBody>To get started, create your first topic </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
           <ButtonLink variant="primary" href={createHref}>

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/EmptyStateNoTopics.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/EmptyStateNoTopics.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { ButtonLink } from "@/components/ButtonLink";
+import { useHelp } from "@/components/Quickstarts/HelpContainer";
+import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+} from "@/libs/patternfly/react-core";
+import { PlusCircleIcon } from "@patternfly/react-icons";
+
+export function EmptyStateNoTopics({ createHref }: { createHref: string }) {
+  const openHelp = useHelp();
+  return (
+    <EmptyState>
+      <EmptyStateHeader
+        titleText="No topics"
+        headingLevel="h4"
+        icon={<EmptyStateIcon icon={PlusCircleIcon} />}
+      />
+      <EmptyStateBody>
+        For help getting started, access the{" "}
+        <a
+          onClick={() => {
+            openHelp("connect-to-cluster"); // TODO: change this
+          }}
+        >
+          quick start guide
+        </a>
+      </EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <ButtonLink variant="primary" href={createHref}>
+            Create a topic
+          </ButtonLink>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+}

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
@@ -11,7 +11,11 @@ import { TableVariant } from "@/libs/patternfly/react-table";
 import { Link, useRouter } from "@/navigation";
 import { useFilterParams } from "@/utils/useFilterParams";
 import { Icon, Tooltip } from "@patternfly/react-core";
-import { HelpIcon, OkIcon, WarningTriangleIcon } from "@patternfly/react-icons";
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  HelpIcon,
+} from "@patternfly/react-icons";
 import { useFormatter, useTranslations } from "next-intl";
 import { useOptimistic, useTransition } from "react";
 
@@ -234,7 +238,7 @@ export function TopicsTable({
                 {inSync && (
                   <>
                     <Icon status={"success"}>
-                      <OkIcon />
+                      <CheckCircleIcon />
                     </Icon>
                     &nbsp;In-sync
                   </>
@@ -242,7 +246,7 @@ export function TopicsTable({
                 {!inSync && (
                   <>
                     <Icon status={"warning"}>
-                      <WarningTriangleIcon />
+                      <ExclamationTriangleIcon />
                     </Icon>
                     &nbsp;Under replicated
                   </>

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
@@ -36,7 +36,8 @@ export type TopicsTableProps = {
   canCreate: boolean;
   page: number;
   perPage: number;
-  search: string | undefined;
+  id: string | undefined;
+  name: string | undefined;
   sort: TopicsTableColumn;
   sortDir: "asc" | "desc";
   includeHidden: boolean;
@@ -46,7 +47,8 @@ export type TopicsTableProps = {
 };
 
 type State = {
-  search: string | undefined;
+  id: string | undefined;
+  name: string | undefined;
   topics: TopicList[] | undefined;
   perPage: number;
   sort: TopicsTableColumn;
@@ -60,7 +62,8 @@ export function TopicsTable({
   topicsCount,
   page,
   perPage,
-  search,
+  id,
+  name,
   sort,
   sortDir,
   includeHidden,
@@ -79,7 +82,8 @@ export function TopicsTable({
   >(
     {
       topics,
-      search,
+      id,
+      name,
       perPage,
       sort,
       sortDir,
@@ -100,7 +104,7 @@ export function TopicsTable({
     startTransition(() => {
       _updateUrl({});
       addOptimistic({
-        search: undefined,
+        name: undefined,
       });
     });
   }
@@ -130,7 +134,7 @@ export function TopicsTable({
       data={state.topics}
       emptyStateNoData={<EmptyStateNoTopics createHref={`${baseurl}/create`} />}
       emptyStateNoResults={<EmptyStateNoMatchFound onClear={clearFilters} />}
-      isFiltered={search !== undefined}
+      isFiltered={name !== undefined || id !== undefined}
       ariaLabel={"Topics"}
       columns={TopicsTableColumns}
       isColumnSortable={(col) => {
@@ -174,7 +178,7 @@ export function TopicsTable({
         switch (column) {
           case "name":
             return (
-              <Th key={key} width={40} dataLabel={"Topic"}>
+              <Th key={key} width={30} dataLabel={"Topic"}>
                 Name
               </Th>
             );
@@ -316,23 +320,47 @@ export function TopicsTable({
       filters={{
         Name: {
           type: "search",
-          chips: state.search ? [state.search] : [],
-          onSearch: (search) => {
+          chips: state.name ? [state.name] : [],
+          onSearch: (name) => {
             startTransition(() => {
-              updateUrl({ search });
-              addOptimistic({ search });
+              updateUrl({ name });
+              addOptimistic({ name });
             });
           },
           onRemoveChip: () => {
             startTransition(() => {
-              updateUrl({ search: undefined });
-              addOptimistic({ search: undefined });
+              updateUrl({ name: undefined });
+              addOptimistic({ name: undefined });
             });
           },
           onRemoveGroup: () => {
             startTransition(() => {
-              updateUrl({ search: undefined });
-              addOptimistic({ search: undefined });
+              updateUrl({ name: undefined });
+              addOptimistic({ name: undefined });
+            });
+          },
+          validate: (value) => value.length >= 3,
+          errorMessage: "At least 3 characters",
+        },
+        "Topic ID": {
+          type: "search",
+          chips: state.id ? [state.id] : [],
+          onSearch: (id) => {
+            startTransition(() => {
+              updateUrl({ id });
+              addOptimistic({ id });
+            });
+          },
+          onRemoveChip: () => {
+            startTransition(() => {
+              updateUrl({ id: undefined });
+              addOptimistic({ id: undefined });
+            });
+          },
+          onRemoveGroup: () => {
+            startTransition(() => {
+              updateUrl({ id: undefined });
+              addOptimistic({ id: undefined });
             });
           },
           validate: (value) => value.length >= 3,

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
@@ -16,7 +16,7 @@ import {
   ExclamationTriangleIcon,
   HelpIcon,
 } from "@patternfly/react-icons";
-import { useFormatter, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 import { useOptimistic, useTransition } from "react";
 
 export const TopicsTableColumns = [
@@ -75,7 +75,6 @@ export function TopicsTable({
   nextPageCursor,
   prevPageCursor,
 }: TopicsTableProps) {
-  const format = useFormatter();
   const t = useTranslations("topics");
   const router = useRouter();
   const _updateUrl = useFilterParams({ perPage, sort, sortDir, includeHidden });
@@ -273,7 +272,7 @@ export function TopicsTable({
                   variant={"link"}
                   href={`${baseurl}/${row.id}/partitions`}
                 >
-                  {format.number(row.attributes.partitions.length)}
+                  <Number value={row.attributes.partitions.length} />
                 </ButtonLink>
               </Td>
             );
@@ -420,7 +419,7 @@ export function TopicsTable({
               addOptimistic({ includeHidden: !checked });
             })
           }
-          className={"pf-v5-u-py-xs pf-v5-u-px-md"}
+          className={"pf-v5-u-py-xs"}
         />,
       ]}
       variant={TableVariant.compact}

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/page.tsx
@@ -22,7 +22,8 @@ export default function TopicsPage({
 }: {
   params: KafkaParams;
   searchParams: {
-    search: string | undefined;
+    id: string | undefined;
+    name: string | undefined;
     perPage: string | undefined;
     sort: string | undefined;
     sortDir: string | undefined;
@@ -30,7 +31,8 @@ export default function TopicsPage({
     hidden: string | undefined;
   };
 }) {
-  const search = searchParams["search"];
+  const id = searchParams["id"];
+  const name = searchParams["name"];
   const pageSize = stringToInt(searchParams.perPage) || 20;
   const sort = (searchParams["sort"] || "name") as SortableTopicsTableColumns;
   const sortDir = (searchParams["sortDir"] || "asc") as "asc" | "desc";
@@ -44,7 +46,8 @@ export default function TopicsPage({
           <TopicsTable
             topics={undefined}
             topicsCount={0}
-            search={search}
+            id={id}
+            name={name}
             perPage={pageSize}
             sort={sort}
             sortDir={sortDir}
@@ -58,7 +61,8 @@ export default function TopicsPage({
         }
       >
         <ConnectedTopicsTable
-          search={search}
+          id={id}
+          name={name}
           sort={sort}
           sortDir={sortDir}
           pageSize={pageSize}
@@ -73,7 +77,8 @@ export default function TopicsPage({
 
 async function ConnectedTopicsTable({
   kafkaId,
-  search,
+  id,
+  name,
   sortDir,
   sort,
   pageCursor,
@@ -81,14 +86,16 @@ async function ConnectedTopicsTable({
   includeHidden,
 }: {
   sort: SortableTopicsTableColumns;
-  search: string | undefined;
+  id: string | undefined;
+  name: string | undefined;
   sortDir: "asc" | "desc";
   pageSize: number;
   pageCursor: string | undefined;
   includeHidden: boolean;
 } & KafkaParams) {
   const topics = await getTopics(kafkaId, {
-    search,
+    id,
+    name,
     sort: sortMap[sort],
     sortDir,
     pageSize,
@@ -108,7 +115,8 @@ async function ConnectedTopicsTable({
     <TopicsTable
       topics={topics.data}
       topicsCount={topics.meta.page.total}
-      search={search}
+      id={id}
+      name={name}
       perPage={pageSize}
       sort={sort}
       sortDir={sortDir}

--- a/ui/components/table/EmptyStateNoMatchFound.tsx
+++ b/ui/components/table/EmptyStateNoMatchFound.tsx
@@ -1,0 +1,32 @@
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+} from "@/libs/patternfly/react-core";
+import { SearchIcon } from "@/libs/patternfly/react-icons";
+
+export function EmptyStateNoMatchFound({ onClear }: { onClear: () => void }) {
+  return (
+    <EmptyState>
+      <EmptyStateHeader
+        titleText="No results found"
+        headingLevel="h4"
+        icon={<EmptyStateIcon icon={SearchIcon} />}
+      />
+      <EmptyStateBody>
+        No results match the filter criteria. Clear all filters and try again.
+      </EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button variant="link" onClick={onClear}>
+            Clear all filters
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+}

--- a/ui/components/table/TableView.tsx
+++ b/ui/components/table/TableView.tsx
@@ -197,17 +197,16 @@ export const TableView = <TRow, TCol>({
             <OverflowMenu breakpoint={breakpoint}>
               <OverflowMenuContent isPersistent>
                 <OverflowMenuGroup isPersistent groupType="button">
-                  <OverflowMenuItem>
-                    {actions.map((a, idx) => (
+                  {actions.map((a, idx) => (
+                    <OverflowMenuItem key={idx}>
                       <Button
-                        key={idx}
                         variant={a.isPrimary ? "primary" : undefined}
                         onClick={a.onClick}
                       >
                         {a.label}
                       </Button>
-                    ))}
-                  </OverflowMenuItem>
+                    </OverflowMenuItem>
+                  ))}
                 </OverflowMenuGroup>
               </OverflowMenuContent>
               <OverflowMenuControl>

--- a/ui/components/table/TableView.tsx
+++ b/ui/components/table/TableView.tsx
@@ -194,61 +194,66 @@ export const TableView = <TRow, TCol>({
 
           {/* responsive action buttons, fallback on a dropdown on small viewports */}
           {actions ? (
-            <OverflowMenu breakpoint={breakpoint}>
-              <OverflowMenuContent isPersistent>
-                <OverflowMenuGroup isPersistent groupType="button">
-                  {actions.map((a, idx) => (
-                    <OverflowMenuItem key={idx}>
-                      <Button
-                        variant={a.isPrimary ? "primary" : undefined}
-                        onClick={a.onClick}
+            <ToolbarItem>
+              <OverflowMenu breakpoint={breakpoint}>
+                <OverflowMenuContent isPersistent>
+                  <OverflowMenuGroup isPersistent groupType="button">
+                    {actions.map((a, idx) => (
+                      <OverflowMenuItem key={idx}>
+                        <Button
+                          variant={a.isPrimary ? "primary" : undefined}
+                          onClick={a.onClick}
+                        >
+                          {a.label}
+                        </Button>
+                      </OverflowMenuItem>
+                    ))}
+                  </OverflowMenuGroup>
+                </OverflowMenuContent>
+                <OverflowMenuControl>
+                  <Dropdown
+                    isPlain
+                    toggle={(toggleRef) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        aria-label="kebab dropdown toggle"
+                        variant="plain"
+                        onClick={() => toggleIsActionsOpen((o) => !o)}
+                        isExpanded={isActionsOpen}
+                      >
+                        <EllipsisVIcon />
+                      </MenuToggle>
+                    )}
+                    shouldFocusToggleOnSelect
+                    isOpen={isActionsOpen}
+                  >
+                    {actions.map((a, idx) => (
+                      <OverflowMenuDropdownItem
+                        key={idx}
+                        onClick={() => {
+                          a.onClick();
+                          toggleIsActionsOpen(false);
+                        }}
                       >
                         {a.label}
-                      </Button>
-                    </OverflowMenuItem>
-                  ))}
-                </OverflowMenuGroup>
-              </OverflowMenuContent>
-              <OverflowMenuControl>
-                <Dropdown
-                  isPlain
-                  toggle={(toggleRef) => (
-                    <MenuToggle
-                      ref={toggleRef}
-                      aria-label="kebab dropdown toggle"
-                      variant="plain"
-                      onClick={() => toggleIsActionsOpen((o) => !o)}
-                      isExpanded={isActionsOpen}
-                    >
-                      <EllipsisVIcon />
-                    </MenuToggle>
-                  )}
-                  shouldFocusToggleOnSelect
-                  isOpen={isActionsOpen}
-                >
-                  {actions.map((a, idx) => (
-                    <OverflowMenuDropdownItem
-                      key={idx}
-                      onClick={() => {
-                        a.onClick();
-                        toggleIsActionsOpen(false);
-                      }}
-                    >
-                      {a.label}
-                    </OverflowMenuDropdownItem>
-                  ))}
-                </Dropdown>
-              </OverflowMenuControl>
-            </OverflowMenu>
+                      </OverflowMenuDropdownItem>
+                    ))}
+                  </Dropdown>
+                </OverflowMenuControl>
+              </OverflowMenu>
+            </ToolbarItem>
           ) : null}
 
           {/* icon buttons */}
           {tools && (
-            <ToolbarGroup variant="icon-button-group">
-              {tools.map((t, idx) => (
-                <ToolbarItem key={idx}>{t}</ToolbarItem>
-              ))}
-            </ToolbarGroup>
+            <>
+              <ToolbarItem variant="separator"></ToolbarItem>
+              <ToolbarGroup variant="icon-button-group">
+                {tools.map((t, idx) => (
+                  <ToolbarItem key={idx}>{t}</ToolbarItem>
+                ))}
+              </ToolbarGroup>
+            </>
           )}
 
           {/* pagination controls */}

--- a/ui/components/tableToolbar/ChipFilter/ChipFilter.tsx
+++ b/ui/components/tableToolbar/ChipFilter/ChipFilter.tsx
@@ -49,6 +49,7 @@ export function ChipFilter({ filters, breakpoint = "md" }: ChipFilterProps) {
         variant={"search-filter"}
         visibility={{ default: "hidden", [breakpoint]: "visible" }}
         data-testid={"large-viewport-toolbar"}
+        widths={{ default: "400px" }}
       >
         <InputGroup>
           {options.length > 1 && (

--- a/ui/components/tableToolbar/ChipFilter/components/FilterCheckbox.tsx
+++ b/ui/components/tableToolbar/ChipFilter/components/FilterCheckbox.tsx
@@ -33,7 +33,7 @@ export function FilterCheckbox({
             } as React.CSSProperties
           }
         >
-          {t("common.search_hint", { label })}
+          {t("common.search_hint", { label: label.toLocaleLowerCase() })}
         </MenuToggle>
       )}
     >

--- a/ui/components/tableToolbar/ChipFilter/components/FilterSearch.tsx
+++ b/ui/components/tableToolbar/ChipFilter/components/FilterSearch.tsx
@@ -10,7 +10,7 @@ export const FilterSearch: VoidFunctionComponent<
 
   return (
     <SearchInput
-      placeholder={t("search_hint", { label })}
+      placeholder={t("search_hint", { label: label.toLocaleLowerCase() })}
       onSearch={onSearch}
       validate={validate}
       errorMessage={errorMessage}

--- a/ui/utils/useFilterParams.ts
+++ b/ui/utils/useFilterParams.ts
@@ -2,7 +2,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useCallback } from "react";
 
 export function useFilterParams(
-  params: Record<string, string | number | null | undefined>,
+  params: Record<string, string | number | boolean | null | undefined>,
 ) {
   const router = useRouter();
   const pathname = usePathname();
@@ -21,7 +21,7 @@ export function useFilterParams(
 
   return useCallback(
     function updateUrl(
-      newParams: Record<string, string | number | null | undefined>,
+      newParams: Record<string, string | number | boolean | null | undefined>,
     ) {
       const updatedParams = {
         ...params,


### PR DESCRIPTION
Update the Topics page header to be in sync with the designs. The warning icon will always show zero as for the moment we don't have the count of topics that are in-sync and under replicated.

Connect the search input to search in the topic names.

Add a switch to show/hide internal topics (hide is the default). not in sync. Part of #165.

Add a status column to show the in-sync or under replicated state of a topic. This is done by looking for a replica amongst all partitions that hold the topic that is flagged as not in sync.

Reorder the columns.

Change the "Edit properties" action to "Edit configuration". Part of #142.

Change the column name "Messages" to "Record count".

Add the right empty states for when there are no topics and for when a search doesn't produce results.

<img width="1371" alt="image" src="https://github.com/eyefloaters/console/assets/966316/edc204a3-512e-4f9c-83c3-88643bccae7d">

![image](https://github.com/eyefloaters/console/assets/966316/ecc81d56-efdd-442c-9029-855bfbe0d84a)

![image](https://github.com/eyefloaters/console/assets/966316/e2ca6376-4bc7-44b8-a52f-415c605d8d16)

<img width="1374" alt="image" src="https://github.com/eyefloaters/console/assets/966316/9f1076ae-eb8e-4a6b-958c-a74b452e8ebc">
