### PR TITLE
Allow selecting columns to see in the message browser

### DIFF
--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
@@ -1,4 +1,3 @@
-import { Modal } from "@/libs/patternfly/react-core";
 import {
   Button,
   DataList,
@@ -7,9 +6,10 @@ import {
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  Modal,
   Text,
   TextContent,
-} from "@patternfly/react-core";
+} from "@/libs/patternfly/react-core";
 import { useState } from "react";
 
 export const columns = [
@@ -23,15 +23,19 @@ export const columns = [
 ] as const;
 export type Column = (typeof columns)[number];
 
-export const columnLabels: Record<Column, string> = {
-  key: "Key",
-  headers: "Headers",
-  partition: "Partition",
-  value: "Value",
-  offset: "Offset",
-  timestamp: "Timestamp (local)",
-  timestampUTC: "Timestamp (UTC)",
-};
+export function useColumnLabels() {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const columnLabels: Record<Column, string> = {
+    key: "Key",
+    headers: "Headers",
+    partition: "Partition",
+    value: "Value",
+    offset: "Offset",
+    timestamp: `Timestamp (${timeZone})`,
+    timestampUTC: "Timestamp (UTC)",
+  };
+  return columnLabels;
+}
 
 export function ColumnsModal({
   isOpen,
@@ -44,6 +48,7 @@ export function ColumnsModal({
   onConfirm: (columns: Column[]) => void;
   onCancel: () => void;
 }) {
+  const columnLabels = useColumnLabels();
   const [selectedColumns, setSelectedColumns] = useState(initialValue);
 
   function selectAllColumns() {

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
@@ -13,8 +13,8 @@ import {
 import { useState } from "react";
 
 export const columns = [
-  "partitions",
   "offset",
+  "partition",
   "timestamp",
   "timestampUTC",
   "key",
@@ -26,7 +26,7 @@ export type Column = (typeof columns)[number];
 export const columnLabels: Record<Column, string> = {
   key: "Key",
   headers: "Headers",
-  partitions: "Partitions",
+  partition: "Partition",
   value: "Value",
   offset: "Offset",
   timestamp: "Timestamp (local)",

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
@@ -1,0 +1,119 @@
+import { Modal } from "@/libs/patternfly/react-core";
+import {
+  Button,
+  DataList,
+  DataListCell,
+  DataListCheck,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Text,
+  TextContent,
+} from "@patternfly/react-core";
+import { useState } from "react";
+
+export const columns = [
+  "partitions",
+  "offset",
+  "timestamp",
+  "timestampUTC",
+  "key",
+  "headers",
+  "value",
+] as const;
+export type Column = (typeof columns)[number];
+
+export const columnLabels: Record<Column, string> = {
+  key: "Key",
+  headers: "Headers",
+  partitions: "Partitions",
+  value: "Value",
+  offset: "Offset",
+  timestamp: "Timestamp (local)",
+  timestampUTC: "Timestamp (UTC)",
+};
+
+export function ColumnsModal({
+  isOpen,
+  selectedColumns: initialValue,
+  onConfirm,
+  onCancel,
+}: {
+  isOpen: boolean;
+  selectedColumns: Column[];
+  onConfirm: (columns: Column[]) => void;
+  onCancel: () => void;
+}) {
+  const [selectedColumns, setSelectedColumns] = useState(initialValue);
+
+  function selectAllColumns() {
+    setSelectedColumns([...columns]);
+  }
+
+  return (
+    <Modal
+      title="Manage columns"
+      isOpen={isOpen}
+      variant="small"
+      description={
+        <TextContent>
+          <Text component={"p"}>
+            Selected fields will be displayed in the table.
+          </Text>
+          <Button isInline onClick={selectAllColumns} variant="link">
+            Select all
+          </Button>
+        </TextContent>
+      }
+      onClose={onCancel}
+      actions={[
+        <Button
+          key="save"
+          variant="primary"
+          onClick={() => onConfirm(selectedColumns)}
+          isDisabled={selectedColumns.length === 0}
+        >
+          Save
+        </Button>,
+        <Button key="cancel" variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <DataList
+        aria-label="Table column management"
+        id="table-column-management"
+        isCompact
+      >
+        {columns.map((c) => (
+          <DataListItem key={c} aria-labelledby={c}>
+            <DataListItemRow>
+              <DataListCheck
+                aria-labelledby={c}
+                checked={selectedColumns.includes(c)}
+                name={`check-${c}`}
+                id={`check-${c}`}
+                onChange={() =>
+                  setSelectedColumns((sc) => {
+                    if (sc.includes(c)) {
+                      return sc.filter((cc) => cc !== c);
+                    } else {
+                      return [...sc, c];
+                    }
+                  })
+                }
+              />
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell id={c} key={c}>
+                    <label htmlFor={`check-${c}`}>{columnLabels[c]}</label>
+                  </DataListCell>,
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+        ))}
+      </DataList>
+    </Modal>
+  );
+}

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal.tsx
@@ -13,8 +13,7 @@ import {
 import { useState } from "react";
 
 export const columns = [
-  "offset",
-  "partition",
+  "offset-partition",
   "timestamp",
   "timestampUTC",
   "key",
@@ -28,9 +27,8 @@ export function useColumnLabels() {
   const columnLabels: Record<Column, string> = {
     key: "Key",
     headers: "Headers",
-    partition: "Partition",
+    "offset-partition": "Offset",
     value: "Value",
-    offset: "Offset",
     timestamp: `Timestamp (${timeZone})`,
     timestampUTC: "Timestamp (UTC)",
   };

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
@@ -1,9 +1,9 @@
 import { Message } from "@/api/messages/schema";
 import {
   Column,
-  columnLabels,
   columns,
   ColumnsModal,
+  useColumnLabels,
 } from "@/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/ColumnsModal";
 import { FilterGroup } from "@/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/FilterGroup";
 import { NoResultsEmptyState } from "@/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/NoResultsEmptyState";
@@ -51,7 +51,7 @@ const columnWidths: Record<Column, BaseCellProps["width"]> = {
   value: undefined,
 };
 
-const defaultColumns = ["offset", "timestamp", "key", "value"];
+const defaultColumns = ["offset", "timestampUTC", "key", "value"];
 
 export type MessageBrowserProps = {
   isRefreshing: boolean;
@@ -100,6 +100,7 @@ export function MessagesTable({
   onDeselectMessage,
 }: MessageBrowserProps) {
   const t = useTranslations("message-browser");
+  const columnLabels = useColumnLabels();
   const [showColumnsManagement, setShowColumnsManagement] = useState(false);
   const [defaultTab, setDefaultTab] =
     useState<MessageDetailsProps["defaultTab"]>("value");

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/libs/patternfly/react-table";
 import { BaseCellProps } from "@patternfly/react-table";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { PropsWithChildren, useState } from "react";
 import { LimitSelector } from "./LimitSelector";
 import { MessageDetails, MessageDetailsProps } from "./MessageDetails";
 import { NoDataCell } from "./NoDataCell";
@@ -47,7 +47,7 @@ const columnWidths: Record<Column, BaseCellProps["width"]> = {
   timestamp: 15,
   timestampUTC: 15,
   headers: 20,
-  partitions: 10,
+  partition: 10,
   value: undefined,
 };
 
@@ -163,8 +163,14 @@ export function MessagesTable({
                 columns={columns.filter((c) => selectedColumns.includes(c))}
                 data={messages}
                 expectedLength={messages.length}
-                renderHeader={({ column, Th, key }) => (
-                  <Th key={key} width={columnWidths[column]}>
+                renderHeader={({ colIndex, column, Th, key }) => (
+                  <Th
+                    key={key}
+                    width={columnWidths[column]}
+                    isStickyColumn={colIndex === 0}
+                    hasRightBorder={colIndex === 0}
+                    modifier={"nowrap"}
+                  >
                     {columnLabels[column]}
                   </Th>
                 )}
@@ -172,43 +178,58 @@ export function MessagesTable({
                   const empty = (
                     <NoDataCell columnLabel={columnLabels[column]} />
                   );
+
+                  function Cell({ children }: PropsWithChildren) {
+                    return (
+                      <Td
+                        key={key}
+                        dataLabel={columnLabels[column]}
+                        isStickyColumn={colIndex === 0}
+                        hasRightBorder={colIndex === 0}
+                        modifier={"nowrap"}
+                      >
+                        {children}
+                      </Td>
+                    );
+                  }
+
                   switch (column) {
+                    case "partition":
+                      return (
+                        <Cell>
+                          <Number value={row.attributes.partition} />
+                        </Cell>
+                      );
                     case "offset":
                       return (
-                        <Td key={key} dataLabel={columnLabels[column]}>
+                        <Cell>
                           <Number value={row.attributes.offset} />
-                        </Td>
-                      );
-                    case "partitions":
-                      return (
-                        <Td key={key} dataLabel={columnLabels[column]}>
-                          <Number value={row.attributes.partition} />
-                        </Td>
+                        </Cell>
                       );
                     case "timestamp":
                       return (
-                        <Td key={key} dataLabel={columnLabels[column]}>
+                        <Cell>
                           <DateTime
                             value={row.attributes.timestamp}
                             dateStyle={"short"}
                             timeStyle={"medium"}
                           />
-                        </Td>
+                        </Cell>
                       );
                     case "timestampUTC":
                       return (
-                        <Td key={key} dataLabel={columnLabels[column]}>
+                        <Cell>
                           <DateTime
                             value={row.attributes.timestamp}
                             dateStyle={"short"}
                             timeStyle={"medium"}
                             tz={"UTC"}
                           />
-                        </Td>
+                        </Cell>
                       );
                     case "key":
                       return (
-                        <Td key={key} dataLabel={columnLabels[column]}>
+                        <Cell>
                           {row.attributes.key ? (
                             <UnknownValuePreview
                               value={row.attributes.key}
@@ -217,11 +238,11 @@ export function MessagesTable({
                           ) : (
                             empty
                           )}
-                        </Td>
+                        </Cell>
                       );
                     case "headers":
                       return (
-                        <Td key={key} dataLabel={columnLabels[column]}>
+                        <Cell>
                           {Object.keys(row.attributes.headers).length > 0 ? (
                             <UnknownValuePreview
                               value={beautifyUnknownValue(
@@ -235,20 +256,24 @@ export function MessagesTable({
                           ) : (
                             empty
                           )}
-                        </Td>
+                        </Cell>
                       );
                     case "value":
-                      return row.attributes.value ? (
-                        <UnknownValuePreview
-                          value={row.attributes.value}
-                          truncateAt={149}
-                          onClick={() => {
-                            setDefaultTab("value");
-                            onSelectMessage(row);
-                          }}
-                        />
-                      ) : (
-                        empty
+                      return (
+                        <Cell>
+                          {row.attributes.value ? (
+                            <UnknownValuePreview
+                              value={row.attributes.value}
+                              truncateAt={149}
+                              onClick={() => {
+                                setDefaultTab("value");
+                                onSelectMessage(row);
+                              }}
+                            />
+                          ) : (
+                            empty
+                          )}
+                        </Cell>
                       );
                   }
                 }}

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
@@ -20,6 +20,8 @@ import {
   Drawer,
   DrawerContent,
   PageSection,
+  Text,
+  TextContent,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -28,11 +30,11 @@ import {
 } from "@/libs/patternfly/react-core";
 import { FilterIcon } from "@/libs/patternfly/react-icons";
 import {
+  BaseCellProps,
   InnerScrollContainer,
   OuterScrollContainer,
   TableVariant,
 } from "@/libs/patternfly/react-table";
-import { BaseCellProps } from "@patternfly/react-table";
 import { useTranslations } from "next-intl";
 import { PropsWithChildren, useState } from "react";
 import { LimitSelector } from "./LimitSelector";
@@ -42,12 +44,11 @@ import { UnknownValuePreview } from "./UnknownValuePreview";
 import { beautifyUnknownValue, isSameMessage } from "./utils";
 
 const columnWidths: Record<Column, BaseCellProps["width"]> = {
-  offset: 10,
+  "offset-partition": 10,
   key: 15,
   timestamp: 15,
   timestampUTC: 15,
   headers: 20,
-  partition: 10,
   value: undefined,
 };
 
@@ -195,16 +196,16 @@ export function MessagesTable({
                   }
 
                   switch (column) {
-                    case "partition":
-                      return (
-                        <Cell>
-                          <Number value={row.attributes.partition} />
-                        </Cell>
-                      );
-                    case "offset":
+                    case "offset-partition":
                       return (
                         <Cell>
                           <Number value={row.attributes.offset} />
+                          <TextContent>
+                            <Text component={"small"}>
+                              Partition{" "}
+                              <Number value={row.attributes.partition} />
+                            </Text>
+                          </TextContent>
                         </Cell>
                       );
                     case "timestamp":

--- a/ui/components/table/ResponsiveTable.tsx
+++ b/ui/components/table/ResponsiveTable.tsx
@@ -165,7 +165,6 @@ export const ResponsiveTable = <TRow, TCol>({
       return renderHeader({
         Th,
         key: `header_${column}`,
-
         column,
         colIndex: index,
       });


### PR DESCRIPTION
Adds a "Manage columns" link in the Message browser toolbar
<img width="621" alt="image" src="https://github.com/eyefloaters/console/assets/966316/75ab9ff2-9e5e-4a75-b70a-e5c350236522">

Clicking it will show a modal where the user can manage the visible columns
<img width="1237" alt="image" src="https://github.com/eyefloaters/console/assets/966316/b40127ae-48be-4b81-adfa-f83664c166be">

Any selection performed there will be persisted on the browser's local storage. Refreshing (or revisiting) the page will keep the previously selected columns. The setting is global for the message browser, it's not specific to a particular topic.
