### PR TITLE
Use danger color and exclamation-circle icon for offline topic status

### DIFF
--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
@@ -13,6 +13,7 @@ import { useFilterParams } from "@/utils/useFilterParams";
 import { Icon, Tooltip } from "@patternfly/react-core";
 import {
   CheckCircleIcon,
+  ExclamationCircleIcon,
   ExclamationTriangleIcon,
   HelpIcon,
 } from "@patternfly/react-icons";
@@ -251,8 +252,8 @@ export function TopicsTable({
                     ),
                     "Offline": (
                       <>
-                        <Icon status={"warning"}>
-                          <ExclamationTriangleIcon />
+                        <Icon status={"danger"}>
+                          <ExclamationCircleIcon />
                         </Icon>
                         &nbsp;Offline
                       </>


### PR DESCRIPTION
Fix offline topic status appearance, as discussed in https://github.com/eyefloaters/console/pull/219#issuecomment-1853395070

![image](https://github.com/eyefloaters/console/assets/20868526/ce9bdec5-afa2-4923-93c3-b2c706c7b92b)
