### PR TITLE
Set milestone on dependabot PRs, approve and merge patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,5 @@ updates:
 - package-ecosystem: "npm"
   directory: "/ui"
   schedule:
-    interval: weekly
+    interval: daily
   open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-auto.yml
+++ b/.github/workflows/dependabot-auto.yml
@@ -1,0 +1,52 @@
+name: Dependabot Automation
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Project metadata
+        uses: radcortez/project-metadata-action@95ed3b828c4563fb1c1c9f4c319eceb9ce7de1b3
+        id: projmeta
+        with:
+          metadata-file-path: '.github/project.yml'
+
+      - name: Determine milestone
+        id: milestone
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const nextVersion = "${{ steps.projmeta.outputs.next-version }}";
+            core.setOutput('next-version', nextVersion.replace("-SNAPSHOT", ""));
+
+      - name: Set PR milestone
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR_URL" --milestone "${{ steps.milestone.outputs.next-version }}"
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Merge PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           milestone-title: ${{steps.metadata.outputs.current-version}}
+          milestone-next: ${{steps.metadata.outputs.next-version}}
 
       - name: Image Update
         uses: renovatebot/github-action@v39.2.3


### PR DESCRIPTION
This will only auto-approve/auto-merge patch releases. Minor and major updates still require a dev's approval and merge.