### PR TITLE
Map consumer group counts and Kafka conditions to cluster overview

### DIFF
--- a/ui/api/consumerGroups/actions.ts
+++ b/ui/api/consumerGroups/actions.ts
@@ -31,6 +31,7 @@ export async function getConsumerGroup(
 export async function getConsumerGroups(
   kafkaId: string,
   params: {
+    fields?: string;
     pageSize?: number;
     pageCursor?: string;
     sort?: string;
@@ -39,8 +40,7 @@ export async function getConsumerGroups(
 ): Promise<ConsumerGroupsResponse> {
   const sp = new URLSearchParams(
     filterUndefinedFromObj({
-      "fields[consumerGroups]":
-        "state,simpleConsumerGroup,members,offsets",
+      "fields[consumerGroups]": params.fields ?? "state,simpleConsumerGroup,members,offsets",
       // TODO: pass filter from UI
       "filter[state]": "in,STABLE,PREPARING_REBALANCE,COMPLETING_REBALANCE",
       "page[size]": params.pageSize,

--- a/ui/api/consumerGroups/schema.ts
+++ b/ui/api/consumerGroups/schema.ts
@@ -22,19 +22,19 @@ const MemberDescriptionSchema = z.object({
   groupInstanceId: z.string().nullable().optional(),
   clientId: z.string(),
   host: z.string(),
-  assignments: z.array(PartitionKeySchema),
+  assignments: z.array(PartitionKeySchema).optional(),
 });
 export const ConsumerGroupSchema = z.object({
   id: z.string(),
   type: z.literal("consumerGroups"),
   attributes: z.object({
-    simpleConsumerGroup: z.boolean(),
-    state: z.string(),
-    members: z.array(MemberDescriptionSchema),
+    simpleConsumerGroup: z.boolean().optional(),
+    state: z.string().optional(),
+    members: z.array(MemberDescriptionSchema).optional(),
     partitionAssignor: z.string().nullable().optional(),
     coordinator: NodeSchema.nullable().optional(),
     authorizedOperations: z.array(z.string()).nullable().optional(),
-    offsets: z.array(OffsetAndMetadataSchema),
+    offsets: z.array(OffsetAndMetadataSchema).optional(),
     errors: z.array(ApiError).optional(),
   }),
 });

--- a/ui/api/kafka/actions.ts
+++ b/ui/api/kafka/actions.ts
@@ -49,7 +49,11 @@ export async function getKafkaClusters(): Promise<ClusterList[]> {
 export async function getKafkaCluster(
   clusterId: string,
 ): Promise<ClusterDetail | null> {
-  const url = `${process.env.BACKEND_URL}/api/kafkas/${clusterId}/?fields%5Bkafkas%5D=name,namespace,creationTimestamp,status,kafkaVersion,nodes,controller,authorizedOperations,bootstrapServers,listeners,authType`;
+  const sp = new URLSearchParams({
+    "fields[kafkas]": "name,namespace,creationTimestamp,status,kafkaVersion,nodes,controller,authorizedOperations,bootstrapServers,listeners,authType,conditions"
+  });
+  const kafkaClusterQuery = sp.toString();
+  const url = `${process.env.BACKEND_URL}/api/kafkas/${clusterId}?${kafkaClusterQuery}`;
   try {
     const res = await fetch(url, {
       headers: await getHeaders(),

--- a/ui/api/kafka/schema.ts
+++ b/ui/api/kafka/schema.ts
@@ -42,6 +42,15 @@ const ClusterDetailSchema = z.object({
         authType: z.string().nullable(),
       }),
     ),
+    conditions: z.array(
+      z.object({
+        type: z.string().optional(),
+        status: z.string().optional(),
+        reason: z.string().optional(),
+        message: z.string().optional(),
+        lastTransitionTime: z.string().optional(),
+      }),
+    ),
   }),
 });
 export const ClusterResponse = z.object({

--- a/ui/app/[locale]/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
@@ -97,16 +97,14 @@ export function ConsumerGroupsTable({
               <Td key={key} dataLabel={"Overall lag"}>
                 <Number
                   value={row.attributes.offsets
-                    .map((o) => o.lag)
+                    ?.map((o) => o.lag)
                     // lag values may not be available from API, e.g. when there is an error listing the topic offsets
                     .reduce((acc, v) => (acc ?? NaN) + (v ?? NaN), 0)}
                 />
               </Td>
             );
           case "topics":
-            const allTopics = row.attributes.members.flatMap((m) =>
-              m.assignments.map((a) => a),
-            );
+            const allTopics = row.attributes.members?.flatMap((m) => m.assignments ?? []) ?? [];
             return (
               <Td key={key} dataLabel={"Assigned topics"}>
                 <LabelGroup>
@@ -129,7 +127,7 @@ export function ConsumerGroupsTable({
           case "members":
             return (
               <Td key={key} dataLabel={"Members"}>
-                <Number value={row.attributes.members.length} />
+                <Number value={row.attributes.members?.length} />
               </Td>
             );
         }

--- a/ui/app/[locale]/kafka/[kafkaId]/consumer-groups/[groupId]/MembersTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/consumer-groups/[groupId]/MembersTable.tsx
@@ -29,17 +29,17 @@ export function MembersTable({
   let members: ConsumerGroup["attributes"]["members"] | undefined = undefined;
 
   if (consumerGroup) {
-    if (consumerGroup.attributes.members.length === 0) {
-      members = consumerGroup.attributes.offsets.map((o) => ({
+    if (consumerGroup.attributes.members?.length === 0) {
+      members = ([{
         memberId: "unknown",
         host: "N/A",
         clientId: "unknown",
-        assignments: consumerGroup.attributes.offsets.map((o) => ({
+        assignments: consumerGroup.attributes.offsets?.map((o) => ({
           topicId: o.topicId,
           topicName: o.topicName,
           partition: o.partition,
         })),
-      }));
+      }]);
     } else {
       members = consumerGroup.attributes.members;
     }
@@ -87,12 +87,12 @@ export function MembersTable({
               </Td>
             );
           case "overallLag":
-            const topics = row.assignments.map((a) => a.topicId);
+            const topics = row.assignments?.map((a) => a.topicId);
             return (
               <Td key={key} dataLabel={"Overall lag"}>
                 <Number
                   value={consumerGroup!.attributes.offsets
-                    .filter((o) => topics.includes(o.topicId))
+                    ?.filter((o) => topics?.includes(o.topicId))
                     .map((o) => o.lag)
                     // lag values may not be available from API, e.g. when there is an error listing the topic offsets
                     .reduce((acc, v) => (acc ?? NaN) + (v ?? NaN), 0)}
@@ -102,7 +102,7 @@ export function MembersTable({
           case "assignedPartitions":
             return (
               <Td key={key} dataLabel={"Assigned partitions"}>
-                <Number value={row.assignments.length} />
+                <Number value={row.assignments?.length} />
               </Td>
             );
         }
@@ -112,13 +112,13 @@ export function MembersTable({
       }}
       getExpandedRow={({ row }) => {
         const offsets: ConsumerGroup["attributes"]["offsets"] =
-          row.assignments.map((a) => ({
+          row.assignments?.map((a) => ({
             ...a,
-            ...consumerGroup!.attributes.offsets.find(
+            ...consumerGroup!.attributes.offsets?.find(
               (o) => o.topicId === a.topicId && o.partition === a.partition,
             )!,
           }));
-        offsets.sort((a, b) => a.topicName.localeCompare(b.topicName));
+        offsets?.sort((a, b) => a.topicName.localeCompare(b.topicName));
         return (
           <div className={"pf-v5-u-p-lg"}>
             <LagTable kafkaId={kafkaId} offsets={offsets} />


### PR DESCRIPTION
![image](https://github.com/eyefloaters/console/assets/20868526/03f9ed04-5b73-46cc-bc96-48844567b7db)

Also fix display of consumer group assignments when empty:
![image](https://github.com/eyefloaters/console/assets/20868526/36c052ca-52c3-4db9-8487-60ae41c69126)

![image](https://github.com/eyefloaters/console/assets/20868526/2b27c391-d4f0-4eaa-bb4a-259e70296a40)
