### PR TITLE
Group storybook dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    storybook:
+      patterns:
+      - "storybook"
+      - "@storybook/*"
+      exclude-patterns:
+      - "@storybook/testing-library"


### PR DESCRIPTION
In theory this should give us 1 storybook dependabot PR instead of 7 per day :laughing: 

Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups