### PR TITLE
Replace Button from PF to a plain link with the Button's css classes applied

### DIFF
--- a/ui/app/[locale]/kafka/not-found.tsx
+++ b/ui/app/[locale]/kafka/not-found.tsx
@@ -38,13 +38,10 @@ export default function NotFound() {
             headingLevel={"h1"}
             icon={<EmptyStateIcon icon={PathMissingIcon} />}
           />
-          <EmptyStateBody>
-            The selected cluster is unavailable. Please check the connection and
-            try again.
-          </EmptyStateBody>
+          <EmptyStateBody>The selected cluster is unavailable.</EmptyStateBody>
           <EmptyStateFooter>
             <EmptyStateActions>
-              <ButtonLink href={"/resources"}>Check the connection</ButtonLink>
+              <ButtonLink href={"/"}>Back to the homepage</ButtonLink>
             </EmptyStateActions>
           </EmptyStateFooter>
         </EmptyState>

--- a/ui/components/ButtonLink.tsx
+++ b/ui/components/ButtonLink.tsx
@@ -1,13 +1,16 @@
 "use client";
-import { Button, ButtonProps } from "@/libs/patternfly/react-core";
+import { ButtonProps } from "@/libs/patternfly/react-core";
 import { Link } from "@/navigation";
 import { Route } from "next";
 
 export function ButtonLink<T extends string>({
   href,
-  ...props
+  variant,
+  children,
 }: ButtonProps & { href: Route<T> | URL }) {
   return (
-    <Button {...props} component={(props) => <Link {...props} href={href} />} />
+    <Link className={`pf-v5-c-button pf-m-${variant}`} href={href}>
+      {children}
+    </Link>
   );
 }

--- a/ui/components/table/ResponsiveTable.tsx
+++ b/ui/components/table/ResponsiveTable.tsx
@@ -444,7 +444,6 @@ export const DeletableRow = memo<DeletableRowProps>(
   ({ isDeleted, isSelected, onClick, children, rowOuiaId }) => {
     return (
       <Tr
-        // isHoverable={!isDeleted && onClick !== undefined}
         onRowClick={(e) => {
           if (e?.target instanceof HTMLElement) {
             if (!["a", "button"].includes(e.target.tagName.toLowerCase())) {
@@ -452,7 +451,7 @@ export const DeletableRow = memo<DeletableRowProps>(
             }
           }
         }}
-        isClickable={!!onClick}
+        isClickable={!isDeleted && !!onClick}
         isSelectable={!!onClick}
         ouiaId={rowOuiaId}
         isRowSelected={isSelected}


### PR DESCRIPTION
Fixes #477 

For some reason the Button from PatternFly was causing the component to re-render endlessly, breaking the underlying link. I removed the component and made the link look like a Button using the proper PF classes.