### PR TITLE
Improve scrolling for the message browser and properties pages

### DIFF
--- a/ui/app/[locale]/kafka/[kafkaId]/layout.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/layout.tsx
@@ -24,7 +24,7 @@ export default function KafkaLayout({
 }>) {
   return (
     <>
-      <PageGroup stickyOnBreakpoint={{ default: "top" }}>
+      <PageGroup /*stickyOnBreakpoint={{ default: "top" }}*/>
         <PageBreadcrumb>
           <Breadcrumb>
             <BreadcrumbItem>Kafka clusters</BreadcrumbItem>

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/configuration/ConfigTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/configuration/ConfigTable.tsx
@@ -4,8 +4,8 @@ import { Error } from "@/app/[locale]/kafka/[kafkaId]/topics/create/Errors";
 import { topicMutateErrorToFieldError } from "@/app/[locale]/kafka/[kafkaId]/topics/create/topicMutateErrorToFieldError";
 import { Number } from "@/components/Number";
 import { ResponsiveTableProps, TableView } from "@/components/table";
-import { readonly } from "@/utils/runmode";
 import { usePathname, useRouter } from "@/navigation";
+import { readonly } from "@/utils/runmode";
 import {
   Button,
   FormGroup,
@@ -228,175 +228,185 @@ export function ConfigTable({
           <Error error={error} />
         </PageSection>
       )}
-      <TableView
-        ariaLabel={"Node configuration"}
-        toolbarBreakpoint={"md"}
-        columns={columns}
-        data={filteredData}
-        isFiltered={filteredData.length !== allData.length}
-        onClearAllFilters={onReset}
-        filters={{
-          Property: {
-            type: "search",
-            onSearch: (value) => {
-              router.push(
-                pathname +
-                  "?" +
-                  createQueryString([
-                    { name: "filter", value },
-                    {
-                      name: "data-source",
-                      value: selectedDataSources.join(","),
-                    },
-                  ]),
-              );
-            },
-            errorMessage: "",
-            validate: () => true,
-            onRemoveGroup: () => {
-              router.push(
-                pathname +
-                  "?" +
-                  createQueryString([
-                    { name: "filter", value: "" },
-                    {
-                      name: "data-source",
-                      value: selectedDataSources.join(","),
-                    },
-                  ]),
-              );
-            },
-            chips: propertyFilter ? [propertyFilter] : [],
-            onRemoveChip: () => {
-              router.push(
-                pathname +
-                  "?" +
-                  createQueryString([
-                    { name: "filter", value: "" },
-                    {
-                      name: "data-source",
-                      value: selectedDataSources.join(","),
-                    },
-                  ]),
-              );
-            },
-          },
-          "Data source": {
-            type: "checkbox",
-            options: Object.fromEntries(dataSources.map((s) => [s, s])),
-            onRemoveChip: onRemoveDataSource,
-            chips: selectedDataSources,
-            onRemoveGroup: () => {
-              router.push(
-                pathname +
-                  "?" +
-                  createQueryString([
-                    { name: "filter", value: propertyFilter || "" },
-                    {
-                      name: "data-source",
-                      value: "",
-                    },
-                  ]),
-              );
-            },
-            onToggle: onRemoveDataSource,
-          },
+      <PageSection
+        isFilled={true}
+        hasOverflowScroll={true}
+        aria-label={"Configuration"}
+        style={{
+          height: "calc(100vh - 70px - 137px)",
         }}
-        emptyStateNoData={<div></div>}
-        emptyStateNoResults={<NoResultsEmptyState onReset={onReset} />}
-        onPageChange={() => {}}
-        renderHeader={({ column, key, Th }) => {
-          switch (column) {
-            case "property":
-              return (
-                <Th key={key} dataLabel={"Property"} width={40}>
-                  Property
-                </Th>
-              );
-            case "value":
-              return (
-                <Th key={key} dataLabel={"Value"}>
-                  Value
-                </Th>
-              );
-          }
-        }}
-        renderCell={renderCell}
-        renderActions={({ row: [name, property] }) => {
-          if (readonly()) {
-            return <></>;
-          }
+        padding={{ default: "noPadding" }}
+      >
+        <TableView
+          ariaLabel={"Node configuration"}
+          toolbarBreakpoint={"md"}
+          columns={columns}
+          data={filteredData}
+          isFiltered={filteredData.length !== allData.length}
+          onClearAllFilters={onReset}
+          filters={{
+            Property: {
+              type: "search",
+              onSearch: (value) => {
+                router.push(
+                  pathname +
+                    "?" +
+                    createQueryString([
+                      { name: "filter", value },
+                      {
+                        name: "data-source",
+                        value: selectedDataSources.join(","),
+                      },
+                    ]),
+                );
+              },
+              errorMessage: "",
+              validate: () => true,
+              onRemoveGroup: () => {
+                router.push(
+                  pathname +
+                    "?" +
+                    createQueryString([
+                      { name: "filter", value: "" },
+                      {
+                        name: "data-source",
+                        value: selectedDataSources.join(","),
+                      },
+                    ]),
+                );
+              },
+              chips: propertyFilter ? [propertyFilter] : [],
+              onRemoveChip: () => {
+                router.push(
+                  pathname +
+                    "?" +
+                    createQueryString([
+                      { name: "filter", value: "" },
+                      {
+                        name: "data-source",
+                        value: selectedDataSources.join(","),
+                      },
+                    ]),
+                );
+              },
+            },
+            "Data source": {
+              type: "checkbox",
+              options: Object.fromEntries(dataSources.map((s) => [s, s])),
+              onRemoveChip: onRemoveDataSource,
+              chips: selectedDataSources,
+              onRemoveGroup: () => {
+                router.push(
+                  pathname +
+                    "?" +
+                    createQueryString([
+                      { name: "filter", value: propertyFilter || "" },
+                      {
+                        name: "data-source",
+                        value: "",
+                      },
+                    ]),
+                );
+              },
+              onToggle: onRemoveDataSource,
+            },
+          }}
+          emptyStateNoData={<div></div>}
+          emptyStateNoResults={<NoResultsEmptyState onReset={onReset} />}
+          onPageChange={() => {}}
+          renderHeader={({ column, key, Th }) => {
+            switch (column) {
+              case "property":
+                return (
+                  <Th key={key} dataLabel={"Property"} width={40}>
+                    Property
+                  </Th>
+                );
+              case "value":
+                return (
+                  <Th key={key} dataLabel={"Value"}>
+                    Value
+                  </Th>
+                );
+            }
+          }}
+          renderCell={renderCell}
+          renderActions={({ row: [name, property] }) => {
+            if (readonly()) {
+              return <></>;
+            }
 
-          return isEditing[name] ? (
-            <div
-              className="pf-v5-c-inline-edit pf-m-inline-editable"
-              id="inline-edit-action-group-icon-buttons-example"
-            >
-              <div className="pf-v5-c-inline-edit__group pf-m-action-group pf-m-icon-group">
-                <div className="pf-v5-c-inline-edit__action pf-m-valid">
-                  <Button
-                    variant={"plain"}
-                    isLoading={isEditing[name] === "saving"}
-                    isDisabled={isEditing[name] === "saving"}
-                    onClick={async () => {
-                      setIsEditing((isEditing) => ({
-                        ...isEditing,
-                        [name]: "saving",
-                      }));
-                      const res = await onSaveProperty!(name, options[name]);
-                      if (res === true) {
+            return isEditing[name] ? (
+              <div
+                className="pf-v5-c-inline-edit pf-m-inline-editable"
+                id="inline-edit-action-group-icon-buttons-example"
+              >
+                <div className="pf-v5-c-inline-edit__group pf-m-action-group pf-m-icon-group">
+                  <div className="pf-v5-c-inline-edit__action pf-m-valid">
+                    <Button
+                      variant={"plain"}
+                      isLoading={isEditing[name] === "saving"}
+                      isDisabled={isEditing[name] === "saving"}
+                      onClick={async () => {
+                        setIsEditing((isEditing) => ({
+                          ...isEditing,
+                          [name]: "saving",
+                        }));
+                        const res = await onSaveProperty!(name, options[name]);
+                        if (res === true) {
+                          setIsEditing((isEditing) => ({
+                            ...isEditing,
+                            [name]: undefined,
+                          }));
+                        } else {
+                          if (res !== false) {
+                            setError(res);
+                          } else {
+                            setError("unknown");
+                          }
+                          setIsEditing((isEditing) => ({
+                            ...isEditing,
+                            [name]: "editing",
+                          }));
+                        }
+                      }}
+                    >
+                      <CheckIcon />
+                    </Button>
+                  </div>
+                  <div className="pf-v5-c-inline-edit__action">
+                    <Button
+                      variant={"plain"}
+                      isDisabled={isEditing[name] === "saving"}
+                      onClick={() => {
                         setIsEditing((isEditing) => ({
                           ...isEditing,
                           [name]: undefined,
                         }));
-                      } else {
-                        if (res !== false) {
-                          setError(res);
-                        } else {
-                          setError("unknown");
-                        }
-                        setIsEditing((isEditing) => ({
-                          ...isEditing,
-                          [name]: "editing",
-                        }));
-                      }
-                    }}
-                  >
-                    <CheckIcon />
-                  </Button>
-                </div>
-                <div className="pf-v5-c-inline-edit__action">
-                  <Button
-                    variant={"plain"}
-                    isDisabled={isEditing[name] === "saving"}
-                    onClick={() => {
-                      setIsEditing((isEditing) => ({
-                        ...isEditing,
-                        [name]: undefined,
-                      }));
-                    }}
-                  >
-                    <TimesIcon />
-                  </Button>
+                      }}
+                    >
+                      <TimesIcon />
+                    </Button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ) : (
-            <Button
-              variant={"plain"}
-              onClick={() =>
-                setIsEditing((isEditing) => ({
-                  ...isEditing,
-                  [name]: "editing",
-                }))
-              }
-            >
-              <PencilAltIcon />
-            </Button>
-          );
-        }}
-        variant={TableVariant.compact}
-      />
+            ) : (
+              <Button
+                variant={"plain"}
+                onClick={() =>
+                  setIsEditing((isEditing) => ({
+                    ...isEditing,
+                    [name]: "editing",
+                  }))
+                }
+              >
+                <PencilAltIcon />
+              </Button>
+            );
+          }}
+          variant={TableVariant.compact}
+        />
+      </PageSection>
     </>
   );
 }

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/configuration/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/configuration/page.tsx
@@ -1,8 +1,7 @@
 import { getTopic, updateTopic } from "@/api/topics/actions";
 import { KafkaTopicParams } from "@/app/[locale]/kafka/[kafkaId]/topics/kafkaTopic.params";
-import { readonly } from "@/utils/runmode";
-import { PageSection } from "@/libs/patternfly/react-core";
 import { redirect } from "@/navigation";
+import { readonly } from "@/utils/runmode";
 import { Suspense } from "react";
 import { ConfigTable } from "./ConfigTable";
 
@@ -12,13 +11,11 @@ export default function TopicConfiguration({
   params: KafkaTopicParams;
 }) {
   return (
-    <PageSection isFilled={true}>
-      <Suspense
-        fallback={<ConfigTable topic={undefined} onSaveProperty={undefined} />}
-      >
-        <ConnectedTopicConfiguration params={{ kafkaId, topicId }} />
-      </Suspense>
-    </PageSection>
+    <Suspense
+      fallback={<ConfigTable topic={undefined} onSaveProperty={undefined} />}
+    >
+      <ConnectedTopicConfiguration params={{ kafkaId, topicId }} />
+    </Suspense>
   );
 }
 

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/[topicId]/messages/_components/MessagesTable.tsx
@@ -142,6 +142,10 @@ export function MessagesTable({
       isFilled={true}
       hasOverflowScroll={true}
       aria-label={t("title")}
+      style={{
+        height: "calc(100vh - 70px - 170px)",
+      }}
+      padding={{ default: "noPadding" }}
     >
       <Drawer isInline={true} isExpanded={selectedMessage !== undefined}>
         <DrawerContent


### PR DESCRIPTION
No padding
![image](https://github.com/eyefloaters/console/assets/966316/10a3c1e1-98b7-4994-a6b2-91744393b90a)
Drawer using all the space
![image](https://github.com/eyefloaters/console/assets/966316/0577aff4-819d-4065-83f2-8b95f997bbd5)
Scrolling of the table without breaking the page/drawer
<img width="825" alt="image" src="https://github.com/eyefloaters/console/assets/966316/eae33180-5b6a-464a-bde5-2ac693aae037">

Same for the properties
<img width="1651" alt="image" src="https://github.com/eyefloaters/console/assets/966316/20ddc023-a4a3-459b-8e43-22ee0dae8cc7">

This removes the padding around the tables to give more space to the content, and works around the problem with drawers breaking the inner scrolling of the table and drawer by specifying a fixed height to the table.