### PR TITLE
Initial support for managed KafkaTopic resources

### DIFF
--- a/api/.checkstyle/checkstyle.xml
+++ b/api/.checkstyle/checkstyle.xml
@@ -97,7 +97,7 @@
 
         <module name="ClassFanOutComplexity">
             <!-- default is 20 -->
-            <property name="max" value="44"/>
+            <property name="max" value="50"/>
             <property name="excludedPackages" value="java.time,javax.json,javax.ws.rs,javax.ws.rs.core"/>
         </module>
         <module name="CyclomaticComplexity">

--- a/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreatePartitionsOptions;
@@ -59,7 +60,11 @@ import com.github.eyefloaters.console.api.support.TopicValidation;
 import com.github.eyefloaters.console.api.support.UnknownTopicIdPatch;
 import com.github.eyefloaters.console.api.support.ValidationProxy;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 
 import static org.apache.kafka.clients.admin.NewPartitions.increaseTo;
 
@@ -101,6 +106,13 @@ public class TopicService {
 
     @Inject
     Supplier<Admin> clientSupplier;
+
+    @Inject
+    @Named("KafkaTopics")
+    Map<String, Map<String, Map<String, KafkaTopic>>> managedTopics;
+
+    @Inject
+    KubernetesClient k8s;
 
     @Inject
     ConfigService configService;
@@ -159,7 +171,9 @@ public class TopicService {
 
         return listTopics(adminClient, true)
             .thenApply(list -> list.stream().map(Topic::fromTopicListing).toList())
-            .thenComposeAsync(list -> augmentList(adminClient, list, fetchList, offsetSpec), threadContext.currentContextExecutor())
+            .thenComposeAsync(
+                    list -> augmentList(adminClient, list, fetchList, offsetSpec),
+                    threadContext.currentContextExecutor())
             .thenApply(list -> list.stream()
                     .filter(listSupport)
                     .map(topic -> tallyStatus(statuses, topic))
@@ -167,8 +181,10 @@ public class TopicService {
                     .filter(listSupport::betweenCursors)
                     .sorted(listSupport.getSortComparator())
                     .dropWhile(listSupport::beforePageBegin)
-                    .takeWhile(listSupport::pageCapacityAvailable)
-                    .toList());
+                    .takeWhile(listSupport::pageCapacityAvailable))
+            .thenApplyAsync(
+                    topics -> topics.map(this::setManaged).toList(),
+                    threadContext.currentContextExecutor());
     }
 
     Topic tallyStatus(Map<String, Integer> statuses, Topic topic) {
@@ -192,6 +208,7 @@ public class TopicService {
         CompletableFuture<Topic> describePromise = describeTopics(adminClient, List.of(id), fields, offsetSpec)
             .thenApply(result -> result.get(id))
             .thenApply(result -> result.getOrThrow(CompletionException::new))
+            .thenApplyAsync(this::setManaged, threadContext.currentContextExecutor())
             .toCompletableFuture();
 
         return describePromise.thenComposeAsync(topic -> {
@@ -221,30 +238,65 @@ public class TopicService {
         return describeTopic(topicId, List.of(Topic.Fields.CONFIGS), KafkaOffsetSpec.LATEST)
             .thenApply(topic -> validationService.validate(new TopicValidation.TopicPatchInputs(kafka, topic, patch)))
             .thenApply(TopicValidation.TopicPatchInputs::topic)
-            .thenComposeAsync(topic -> {
-                List<CompletableFuture<Void>> pending = new ArrayList<>();
+            .thenComposeAsync(topic -> getManagedTopic(topic.name())
+                    .map(kafkaTopic -> patchManagedTopic(kafkaTopic, patch, validateOnly))
+                    .orElseGet(() -> patchUnmanagedTopic(topic, patch, validateOnly)),
+                    threadContext.currentContextExecutor());
+    }
 
-                pending.add(maybeCreatePartitions(topic, patch, validateOnly));
-                if (!validateOnly) {
-                    pending.addAll(maybeAlterPartitionAssignments(topic, patch));
+    CompletionStage<Void> patchManagedTopic(KafkaTopic topic, TopicPatch patch, boolean validateOnly) {
+        if (validateOnly) {
+            return CompletableFuture.completedStage(null);
+        }
+
+        Map<String, Object> modifiedConfig = Optional.ofNullable(patch.configs())
+            .map(Map::entrySet)
+            .map(Collection::stream)
+            .orElseGet(Stream::empty)
+            .map(e -> Map.entry(e.getKey(), e.getValue().getValue()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        KafkaTopic modifiedTopic = new KafkaTopicBuilder(topic)
+            .editSpec()
+                .withPartitions(patch.numPartitions())
+                .withReplicas(patch.replicasAssignments()
+                        .values()
+                        .stream()
+                        .findFirst()
+                        .map(Collection::size)
+                        .orElseGet(() -> topic.getSpec().getReplicas()))
+                .addToConfig(modifiedConfig)
+            .endSpec()
+            .build();
+
+        return CompletableFuture.runAsync(() -> k8s.resource(modifiedTopic).serverSideApply());
+    }
+
+    CompletionStage<Void> patchUnmanagedTopic(Topic topic, TopicPatch patch, boolean validateOnly) {
+        List<CompletableFuture<Void>> pending = new ArrayList<>();
+
+        pending.add(maybeCreatePartitions(topic, patch, validateOnly));
+
+        if (!validateOnly) {
+            pending.addAll(maybeAlterPartitionAssignments(topic, patch));
+        }
+
+        pending.add(maybeAlterConfigs(topic, patch, validateOnly));
+
+        return CompletableFuture.allOf(pending.stream().toArray(CompletableFuture[]::new))
+            .whenComplete((nothing, error) -> {
+                if (error != null) {
+                    pending.stream()
+                        .filter(CompletableFuture::isCompletedExceptionally)
+                        .forEach(fut -> fut.exceptionally(ex -> {
+                            if (ex instanceof CompletionException ce) {
+                                ex = ce.getCause();
+                            }
+                            error.addSuppressed(ex);
+                            return null;
+                        }));
                 }
-                pending.add(maybeAlterConfigs(topic, patch, validateOnly));
-
-                return CompletableFuture.allOf(pending.stream().toArray(CompletableFuture[]::new))
-                    .whenComplete((nothing, error) -> {
-                        if (error != null) {
-                            pending.stream()
-                                .filter(CompletableFuture::isCompletedExceptionally)
-                                .forEach(fut -> fut.exceptionally(ex -> {
-                                    if (ex instanceof CompletionException ce) {
-                                        ex = ce.getCause();
-                                    }
-                                    error.addSuppressed(ex);
-                                    return null;
-                                }));
-                        }
-                    });
-            }, threadContext.currentContextExecutor());
+            });
     }
 
     CompletableFuture<Void> maybeCreatePartitions(Topic topic, TopicPatch topicPatch, boolean validateOnly) {
@@ -371,6 +423,31 @@ public class TopicService {
                 .topicIdValues()
                 .get(id)
                 .toCompletionStage();
+    }
+
+    Topic setManaged(Topic topic) {
+        topic.addMeta("managed", getManagedTopic(topic.name())
+                .map(kafkaTopic -> Boolean.TRUE)
+                .orElse(Boolean.FALSE));
+        return topic;
+    }
+
+    Optional<KafkaTopic> getManagedTopic(String topicName) {
+        ObjectMeta kafkaMeta = kafkaCluster.get().getMetadata();
+
+        return Optional.ofNullable(managedTopics.get(kafkaMeta.getNamespace()))
+            .map(clustersInNamespace -> clustersInNamespace.get(kafkaMeta.getName()))
+            .map(topicsInCluster -> topicsInCluster.get(topicName))
+            .filter(this::isManaged);
+    }
+
+    boolean isManaged(KafkaTopic topic) {
+        return Optional.of(topic)
+            .map(KafkaTopic::getMetadata)
+            .map(ObjectMeta::getAnnotations)
+            .map(annotations -> annotations.getOrDefault("strimzi.io/managed", "true"))
+            .map(managed -> !"false".equals(managed))
+            .orElse(true);
     }
 
     CompletionStage<List<Topic>> augmentList(Admin adminClient, List<Topic> list, List<String> fields, String offsetSpec) {

--- a/api/src/main/java/com/github/eyefloaters/console/api/support/InformerFactory.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/support/InformerFactory.java
@@ -1,5 +1,9 @@
 package com.github.eyefloaters.console.api.support;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Startup;
@@ -8,12 +12,21 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+import org.jboss.logging.Logger;
+
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaTopic;
 
 @ApplicationScoped
 public class InformerFactory {
+
+    private static final String STRIMZI_CLUSTER = "strimzi.io/cluster";
+
+    @Inject
+    Logger logger;
 
     @Inject
     KubernetesClient k8s;
@@ -23,6 +36,17 @@ public class InformerFactory {
     @Named("KafkaInformer")
     SharedIndexInformer<Kafka> kafkaInformer;
 
+    @Produces
+    @ApplicationScoped
+    @Named("KafkaTopicInformer")
+    SharedIndexInformer<KafkaTopic> topicInformer;
+
+    @Produces
+    @ApplicationScoped
+    @Named("KafkaTopics")
+    // Keys: namespace -> cluster name -> topic name
+    Map<String, Map<String, Map<String, KafkaTopic>>> topics = new ConcurrentHashMap<>();
+
     /**
      * Initialize CDI beans produced by this factory. Executed on application startup.
      *
@@ -30,9 +54,49 @@ public class InformerFactory {
      */
     void onStartup(@Observes Startup event) {
         kafkaInformer = k8s.resources(Kafka.class).inAnyNamespace().inform();
+        topicInformer = k8s.resources(KafkaTopic.class).inAnyNamespace().inform();
+        topicInformer.addEventHandler(new ResourceEventHandler<KafkaTopic>() {
+            @Override
+            public void onAdd(KafkaTopic topic) {
+                topicMap(topic).ifPresent(map -> map.put(topic.getSpec().getTopicName(), topic));
+            }
+
+            @Override
+            public void onUpdate(KafkaTopic oldTopic, KafkaTopic topic) {
+                onDelete(oldTopic, false);
+                onAdd(topic);
+            }
+
+            @Override
+            public void onDelete(KafkaTopic topic, boolean deletedFinalStateUnknown) {
+                topicMap(topic).ifPresent(map -> map.remove(topic.getSpec().getTopicName()));
+            }
+
+            Optional<Map<String, KafkaTopic>> topicMap(KafkaTopic topic) {
+                String namespace = topic.getMetadata().getNamespace();
+                String clusterName = topic.getMetadata().getLabels().get(STRIMZI_CLUSTER);
+
+                if (clusterName == null) {
+                    logger.warnf("KafkaTopic %s/%s is missing label %s and will be ignored",
+                            namespace,
+                            topic.getMetadata().getName(),
+                            STRIMZI_CLUSTER);
+                    return Optional.empty();
+                }
+
+                Map<String, KafkaTopic> map = topics.computeIfAbsent(namespace, k -> new ConcurrentHashMap<>())
+                        .computeIfAbsent(clusterName, k -> new ConcurrentHashMap<>());
+
+                return Optional.of(map);
+            }
+        });
     }
 
     public void disposeKafkaInformer(@Disposes @Named("KafkaInformer") SharedIndexInformer<Kafka> informer) {
+        informer.close();
+    }
+
+    public void disposeTopicInformer(@Disposes @Named("KafkaTopicInformer") SharedIndexInformer<KafkaTopic> informer) {
         informer.close();
     }
 }

--- a/ui/api/topics/schema.ts
+++ b/ui/api/topics/schema.ts
@@ -70,6 +70,9 @@ export type TopicStatus = z.infer<typeof TopicStatusSchema>;
 const TopicSchema = z.object({
   id: z.string(),
   type: z.literal("topics"),
+  meta: z.object({
+    managed: z.boolean().optional(),
+  }).optional(),
   attributes: z.object({
     name: z.string(),
     status: TopicStatusSchema,
@@ -97,6 +100,7 @@ const TopicListSchema = z.object({
     page: z.object({
       cursor: z.string(),
     }),
+    managed: z.boolean().optional(),
   }),
   attributes: TopicSchema.shape.attributes.pick({
     name: true,

--- a/ui/app/[locale]/kafka/[kafkaId]/@header/topics/[topicId]/TopicHeader.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/@header/topics/[topicId]/TopicHeader.tsx
@@ -96,6 +96,7 @@ async function ConnectedTopicHeader({
   return (
     <AppHeader
       title={topic?.attributes.name}
+      subTitle={(topic?.meta?.managed ?? false) ? "Managed" : "Unmanaged"}
       navigation={
         <PageNavigation>
           <Nav aria-label="Group section navigation" variant="tertiary">

--- a/ui/app/[locale]/kafka/[kafkaId]/@header/topics/[topicId]/TopicHeader.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/@header/topics/[topicId]/TopicHeader.tsx
@@ -1,6 +1,7 @@
 import { getKafkaCluster } from "@/api/kafka/actions";
 import { getTopic } from "@/api/topics/actions";
 import { KafkaTopicParams } from "@/app/[locale]/kafka/[kafkaId]/topics/kafkaTopic.params";
+import { ManagedTopicLabel } from "@/app/components/ManagedTopicLabel";
 import { AppHeader } from "@/components/AppHeader";
 import { NavItemLink } from "@/components/NavItemLink";
 import { Number } from "@/components/Number";
@@ -95,8 +96,12 @@ async function ConnectedTopicHeader({
   const topic = await getTopic(cluster.id, topicId);
   return (
     <AppHeader
-      title={topic?.attributes.name}
-      subTitle={(topic?.meta?.managed ?? false) ? "Managed" : "Unmanaged"}
+      title={
+        <>
+          {topic?.attributes.name}
+          {topic?.meta?.managed === true && <ManagedTopicLabel />}
+        </>
+      }
       navigation={
         <PageNavigation>
           <Nav aria-label="Group section navigation" variant="tertiary">

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
@@ -17,6 +17,7 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   HelpIcon,
+  MigrationIcon,
 } from "@patternfly/react-icons";
 import { useTranslations } from "next-intl";
 import { ReactNode, useOptimistic, useTransition } from "react";
@@ -279,6 +280,13 @@ export function TopicsTable({
             return (
               <Td key={key} dataLabel={"Status"}>
                 {StatusLabel[row.attributes.status]}
+                {(row.meta?.managed ?? false) ?
+                  <>,&nbsp;
+                    <Icon status={"info"}>
+                      <MigrationIcon />
+                    </Icon>
+                    &nbsp;Managed
+                  </> : <></>}
               </Td>
             );
           case "consumerGroups":

--- a/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/topics/(page)/TopicsTable.tsx
@@ -1,15 +1,16 @@
 "use client";
 import { TopicList, TopicStatus } from "@/api/topics/schema";
 import { EmptyStateNoTopics } from "@/app/[locale]/kafka/[kafkaId]/topics/(page)/EmptyStateNoTopics";
+import { ManagedTopicLabel } from "@/app/components/ManagedTopicLabel";
 import { ButtonLink } from "@/components/ButtonLink";
 import { Bytes } from "@/components/Bytes";
 import { Number } from "@/components/Number";
 import { TableView } from "@/components/table";
 import { EmptyStateNoMatchFound } from "@/components/table/EmptyStateNoMatchFound";
-import { readonly } from "@/utils/runmode";
 import { Switch } from "@/libs/patternfly/react-core";
 import { TableVariant } from "@/libs/patternfly/react-table";
 import { Link, useRouter } from "@/navigation";
+import { readonly } from "@/utils/runmode";
 import { useFilterParams } from "@/utils/useFilterParams";
 import { Icon, Tooltip } from "@patternfly/react-core";
 import {
@@ -17,7 +18,6 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   HelpIcon,
-  MigrationIcon,
 } from "@patternfly/react-icons";
 import { useTranslations } from "next-intl";
 import { ReactNode, useOptimistic, useTransition } from "react";
@@ -232,18 +232,16 @@ export function TopicsTable({
           case "status":
             return (
               <Th key={key} dataLabel={"Status"}>
-               Status {" "}
-              <Tooltip
-               style={{whiteSpace:'pre-line'}}
-               content={
-                   `Indicates the replication status of the partitions in the Kafka topic.
+                Status{" "}
+                <Tooltip
+                  style={{ whiteSpace: "pre-line" }}
+                  content={`Indicates the replication status of the partitions in the Kafka topic.
                    A partition is fully replicated when its replicas (followers) are 'in-sync' with the designated partition leader.
                    A partition is under-replicated if partition replicas (followers) are not 'in-sync with their designated partition leader.
-                   If the status shows unavailable, some or all partitions are currently unavailable due to underlying issues.`
-                }
-              >
-                <HelpIcon />
-              </Tooltip>
+                   If the status shows unavailable, some or all partitions are currently unavailable due to underlying issues.`}
+                >
+                  <HelpIcon />
+                </Tooltip>
               </Th>
             );
           case "consumerGroups":
@@ -274,19 +272,13 @@ export function TopicsTable({
                 <Link href={`${baseurl}/${row.id}/messages`}>
                   {row.attributes.name}
                 </Link>
+                {row.meta?.managed === true && <ManagedTopicLabel />}
               </Td>
             );
           case "status":
             return (
               <Td key={key} dataLabel={"Status"}>
                 {StatusLabel[row.attributes.status]}
-                {(row.meta?.managed ?? false) ?
-                  <>,&nbsp;
-                    <Icon status={"info"}>
-                      <MigrationIcon />
-                    </Icon>
-                    &nbsp;Managed
-                  </> : <></>}
               </Td>
             );
           case "consumerGroups":
@@ -321,31 +313,35 @@ export function TopicsTable({
             );
         }
       }}
-      renderActions={({ row, ActionsColumn }) => readonly() ? <></> : (
-        <ActionsColumn
-          items={[
-            {
-              title: "Edit configuration",
-              onClick: () => {
-                startTransition(() => {
-                  router.push(`${baseurl}/${row.id}/configuration`);
-                });
+      renderActions={({ row, ActionsColumn }) =>
+        readonly() ? (
+          <></>
+        ) : (
+          <ActionsColumn
+            items={[
+              {
+                title: "Edit configuration",
+                onClick: () => {
+                  startTransition(() => {
+                    router.push(`${baseurl}/${row.id}/configuration`);
+                  });
+                },
               },
-            },
-            {
-              isSeparator: true,
-            },
-            {
-              title: "Delete topic",
-              onClick: () => {
-                startTransition(() => {
-                  router.push(`${baseurl}/${row.id}/delete`);
-                });
+              {
+                isSeparator: true,
               },
-            },
-          ]}
-        />
-      )}
+              {
+                title: "Delete topic",
+                onClick: () => {
+                  startTransition(() => {
+                    router.push(`${baseurl}/${row.id}/delete`);
+                  });
+                },
+              },
+            ]}
+          />
+        )
+      }
       filters={{
         Name: {
           type: "search",

--- a/ui/app/components/ManagedTopicLabel.tsx
+++ b/ui/app/components/ManagedTopicLabel.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { Label, Tooltip } from "@/libs/patternfly/react-core";
+import { ServicesIcon } from "@/libs/patternfly/react-icons";
+
+export function ManagedTopicLabel() {
+  return (
+    <Tooltip
+      content={
+        "Managed topics are created using the KafkaTopic custom resource and are created and updated in the Kafka cluster by the AMQ Streams Topic Operator."
+      }
+    >
+      <Label
+        isCompact={true}
+        color={"gold"}
+        icon={<ServicesIcon />}
+        className={"pf-v5-u-ml-sm"}
+      >
+        Managed
+      </Label>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
Added a "Managed" indicator to the topic status in the listing, just to demonstrate the data is available. A topic is managed when there is a corresponding `KafkaTopic` CR in Kubernetes.

![image](https://github.com/eyefloaters/console/assets/20868526/e2c1d1e3-d9b9-4155-84f1-655dba288c37)

Also added to subtitle for topic details, but I couldn't figure out how to add an icon...
![image](https://github.com/eyefloaters/console/assets/20868526/9470ce09-fb4e-4328-90d6-9b50d63af73a)
