### PR TITLE
fix: identify configured and un-configured Kafka clusters

### DIFF
--- a/api/src/main/java/com/github/eyefloaters/console/api/model/KafkaCluster.java
+++ b/api/src/main/java/com/github/eyefloaters/console/api/model/KafkaCluster.java
@@ -93,6 +93,7 @@ public class KafkaCluster {
                     .map(entry -> {
                         var rsrc = new KafkaClusterResource(entry);
                         rsrc.addMeta("page", listSupport.buildPageMeta(entry::toCursor));
+                        rsrc.addMeta("configured", entry.isConfigured());
                         return rsrc;
                     })
                     .toList());
@@ -130,6 +131,8 @@ public class KafkaCluster {
     String kafkaVersion;
     String status;
     List<Condition> conditions;
+    @JsonIgnore
+    boolean configured;
 
     public KafkaCluster(String id, List<Node> nodes, Node controller, List<String> authorizedOperations) {
         super();
@@ -246,5 +249,13 @@ public class KafkaCluster {
 
     public void setConditions(List<Condition> conditions) {
         this.conditions = conditions;
+    }
+
+    public boolean isConfigured() {
+        return configured;
+    }
+
+    public void setConfigured(boolean configured) {
+        this.configured = configured;
     }
 }

--- a/ui/api/kafka/schema.ts
+++ b/ui/api/kafka/schema.ts
@@ -10,6 +10,9 @@ export type KafkaNode = z.infer<typeof NodeSchema>;
 export const ClusterListSchema = z.object({
   id: z.string(),
   type: z.literal("kafkas"),
+  meta: z.object({
+    configured: z.boolean(),
+  }),
   attributes: z.object({
     name: z.string(),
     namespace: z.string(),

--- a/ui/app/[locale]/AppLayout.tsx
+++ b/ui/app/[locale]/AppLayout.tsx
@@ -46,7 +46,7 @@ export function AppLayout({ children }: PropsWithChildren) {
 
 async function Clusters() {
   const clusters = await getKafkaClusters();
-  return clusters.map((s, idx) => (
+  return clusters.filter(c => c.meta.configured === true).map((s, idx) => (
     <NavExpandable
       key={s.id}
       title={s.attributes.name}

--- a/ui/app/[locale]/home/ClustersTable.tsx
+++ b/ui/app/[locale]/home/ClustersTable.tsx
@@ -56,21 +56,29 @@ export function ClustersTable({
           case "name":
             return (
               <Td key={key}>
-                <Link href={`/kafka/${row.id}`}>
-                  <Truncate content={row.attributes.name} />
-                </Link>
+                {
+                  row.meta.configured === true ? (
+                    <Link href={`/kafka/${row.id}`}>
+                      <Truncate content={row.attributes.name} />
+                    </Link>
+                  ) : (
+                    <Truncate content={row.attributes.name} />
+                  )
+                }
               </Td>
             );
           case "nodes":
-            return (
+            return row.meta.configured === true ? (
               <Td key={key}>
                 <Suspense fallback={<Skeleton />}>
                   <NodesCell kafkaId={row.id} data={row.extra.nodes} />
                 </Suspense>
               </Td>
+            ) : (
+              <i>Connection not configured</i>
             );
           case "consumers":
-            return (
+            return row.meta.configured === true ? (
               <Td key={key}>
                 <Suspense fallback={<Skeleton />}>
                   <ConsumersCell
@@ -79,9 +87,11 @@ export function ClustersTable({
                   />
                 </Suspense>
               </Td>
+            ) : (
+              <i>Connection not configured</i>
             );
           case "version":
-            return <Td key={key}>{row.attributes.kafkaVersion || "n/a"}</Td>;
+            return <Td key={key}>{row.attributes.kafkaVersion ?? "n/a"}</Td>;
           case "namespace":
             return <Td key={key}>{row.attributes.namespace}</Td>;
         }

--- a/ui/app/[locale]/home/page.tsx
+++ b/ui/app/[locale]/home/page.tsx
@@ -97,7 +97,7 @@ export default function Home() {
                     </Tooltip>
                   </b>
                   <Text component={"small"}>
-                  The last 5 topics this account has accessed from the AMQ 
+                  The last 5 topics this account has accessed from the AMQ
                   Streams console.
                   </Text>
                 </TextContent>
@@ -297,7 +297,14 @@ async function ConnectedClustersTable({
   const allClusters = await clusterPromise;
   const clusters = allClusters.map<EnrichedClusterList>((c) => {
     async function getNodesCounts() {
-      const cluster = await getKafkaCluster(c.id);
+      let cluster;
+
+      if (c.meta.configured === true) {
+        cluster = await getKafkaCluster(c.id);
+      } else {
+        cluster = null;
+      }
+
       if (cluster) {
         return {
           count: cluster.attributes.nodes.length,
@@ -311,8 +318,15 @@ async function ConnectedClustersTable({
     }
 
     async function getConsumerGroupsCount() {
-      const cg = await getConsumerGroups(c.id, {});
-      return cg.meta.page.total || 0;
+      let cg;
+
+      if (c.meta.configured === true) {
+        cg = await getConsumerGroups(c.id, {});
+      } else {
+        cg = null;
+      }
+
+      return cg?.meta.page.total ?? 0;
     }
 
     const ec: EnrichedClusterList = {


### PR DESCRIPTION
Fixes #543 

Changes:
 - links disabled for Kafka clusters without connection configuration
 - broker/consumer groups show _Connection not configured_ rather than details
 - Clusters excluded from the navigation

Sample
![image](https://github.com/eyefloaters/console/assets/20868526/3440d53e-142d-4ccb-8ce4-0b40dffedefd)
