### PR TITLE
Add a Tech Preview banner and relative UI elements

### DIFF
--- a/ui/app/[locale]/AppLayout.tsx
+++ b/ui/app/[locale]/AppLayout.tsx
@@ -6,7 +6,16 @@ import { ClusterDrawer } from "@/app/[locale]/ClusterDrawer";
 import { ClusterDrawerProvider } from "@/app/[locale]/ClusterDrawerProvider";
 import { NavExpandable } from "@/components/NavExpandable";
 import { NavItemLink } from "@/components/NavItemLink";
-import { Nav, NavList, Page } from "@/libs/patternfly/react-core";
+import { TechPreviewPopover } from "@/components/TechPreviewPopover";
+import {
+  Banner,
+  Nav,
+  NavList,
+  Page,
+  Split,
+  SplitItem,
+} from "@/libs/patternfly/react-core";
+import { HelpIcon } from "@/libs/patternfly/react-icons";
 import { PropsWithChildren, Suspense } from "react";
 
 export function AppLayout({ children }: PropsWithChildren) {
@@ -37,7 +46,22 @@ export function AppLayout({ children }: PropsWithChildren) {
     >
       {/*<HelpContainer>*/}
       <ClusterDrawerProvider>
-        <ClusterDrawer>{children}</ClusterDrawer>
+        <ClusterDrawer>
+          <Banner variant={"blue"}>
+            <Split>
+              <SplitItem isFilled={true}>
+                This is a Tech Preview version. You are logged in as an
+                anonymous user with read-only access.
+              </SplitItem>
+              <SplitItem>
+                <TechPreviewPopover>
+                  <HelpIcon />
+                </TechPreviewPopover>
+              </SplitItem>
+            </Split>
+          </Banner>
+          {children}
+        </ClusterDrawer>
       </ClusterDrawerProvider>
       {/*</HelpContainer>*/}
     </Page>
@@ -46,26 +70,28 @@ export function AppLayout({ children }: PropsWithChildren) {
 
 async function Clusters() {
   const clusters = await getKafkaClusters();
-  return clusters.filter(c => c.meta.configured === true).map((s, idx) => (
-    <NavExpandable
-      key={s.id}
-      title={s.attributes.name}
-      url={`/kafka/${s.id}`}
-      startExpanded={idx === 0}
-    >
-      <NavItemLink url={`/kafka/${s.id}/overview`}>
-        Cluster overview
-      </NavItemLink>
-      <NavItemLink url={`/kafka/${s.id}/topics`}>Topics</NavItemLink>
-      <NavItemLink url={`/kafka/${s.id}/nodes`}>Brokers</NavItemLink>
-      {/*
+  return clusters
+    .filter((c) => c.meta.configured === true)
+    .map((s, idx) => (
+      <NavExpandable
+        key={s.id}
+        title={s.attributes.name}
+        url={`/kafka/${s.id}`}
+        startExpanded={idx === 0}
+      >
+        <NavItemLink url={`/kafka/${s.id}/overview`}>
+          Cluster overview
+        </NavItemLink>
+        <NavItemLink url={`/kafka/${s.id}/topics`}>Topics</NavItemLink>
+        <NavItemLink url={`/kafka/${s.id}/nodes`}>Brokers</NavItemLink>
+        {/*
       <NavItemLink url={`/kafka/${s.id}/service-registry`}>
         Service registry
       </NavItemLink>
 */}
-      <NavItemLink url={`/kafka/${s.id}/consumer-groups`}>
-        Consumer groups
-      </NavItemLink>
-    </NavExpandable>
-  ));
+        <NavItemLink url={`/kafka/${s.id}/consumer-groups`}>
+          Consumer groups
+        </NavItemLink>
+      </NavExpandable>
+    ));
 }

--- a/ui/app/[locale]/AppMasthead.tsx
+++ b/ui/app/[locale]/AppMasthead.tsx
@@ -1,7 +1,9 @@
 "use client";
 import { useAppLayout } from "@/app/[locale]/AppLayoutProvider";
+import { TechPreviewPopover } from "@/components/TechPreviewPopover";
 import {
   Button,
+  Label,
   Masthead,
   MastheadContent,
   MastheadMain,
@@ -12,11 +14,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@/libs/patternfly/react-core";
-import {
-  BarsIcon,
-  CogIcon,
-  QuestionCircleIcon,
-} from "@/libs/patternfly/react-icons";
+import { BarsIcon, QuestionCircleIcon } from "@/libs/patternfly/react-icons";
 import { FeedbackModal } from "@patternfly/react-user-feedback";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
@@ -76,12 +74,11 @@ export function AppMasthead() {
                   visibility={{ default: "hidden", lg: "visible" }}
                 >
                   <ToolbarItem>
-                    <Button
-                      aria-label="Settings"
-                      variant={"plain"}
-                      icon={<CogIcon />}
-                      ouiaId={"setting-button"}
-                    />
+                    <TechPreviewPopover>
+                      <Label color={"blue"} isCompact={true}>
+                        Tech preview
+                      </Label>
+                    </TechPreviewPopover>
                   </ToolbarItem>
                   <ToolbarItem>
                     <Button

--- a/ui/components/TechPreviewPopover.stories.tsx
+++ b/ui/components/TechPreviewPopover.stories.tsx
@@ -1,0 +1,15 @@
+import { HelpIcon } from "@patternfly/react-icons";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { TechPreviewPopover as Comp } from "./TechPreviewPopover";
+
+export default {
+  component: Comp,
+} as Meta<typeof Comp>;
+type Story = StoryObj<typeof Comp>;
+
+export const TechPreviewPopover: Story = {
+  args: {
+    children: <HelpIcon />,
+  },
+};

--- a/ui/components/TechPreviewPopover.tsx
+++ b/ui/components/TechPreviewPopover.tsx
@@ -1,0 +1,35 @@
+import { ExternalLink } from "@/components/ExternalLink";
+import { Popover } from "@/libs/patternfly/react-core";
+import { PopoverProps } from "@patternfly/react-core";
+
+export function TechPreviewPopover({
+  children,
+}: {
+  children: PopoverProps["children"];
+}) {
+  return (
+    <Popover
+      triggerAction={"hover"}
+      headerContent={"Technology Preview"}
+      bodyContent={
+        <div>
+          Technology Preview features are not fully supported, may not be
+          functionally complete, and are not suitable for deployment in
+          production. However, these features are provided to the customer as a
+          courtesy and the primary goal is for the feature to gain wider
+          exposure with the goal of full support in the future.
+        </div>
+      }
+      footerContent={
+        <ExternalLink
+          href={"https://redhat.com"}
+          testId={"tech-preview-learn-more"}
+        >
+          Learn more
+        </ExternalLink>
+      }
+    >
+      {children}
+    </Popover>
+  );
+}


### PR DESCRIPTION
![image](https://github.com/eyefloaters/console/assets/966316/0edd78d5-011f-4540-80d4-559fe3657d5c)
<img width="525" alt="image" src="https://github.com/eyefloaters/console/assets/966316/3963a008-2f7d-4804-bff1-8d0d9dbf2440">
<img width="515" alt="image" src="https://github.com/eyefloaters/console/assets/966316/6461479c-fe62-4920-9f3b-f8a89ce1442e">
