### PR TITLE
Escape the consumer group id

### DIFF
--- a/ui/app/[locale]/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/consumer-groups/ConsumerGroupsTable.tsx
@@ -102,7 +102,7 @@ export function ConsumerGroupsTable({
                 dataLabel={t("ConsumerGroupsTable.consumer_group_name")}
               >
                 <Link
-                  href={`/kafka/${kafkaId}/consumer-groups/${row.id === "" ? "+" : row.id}`}
+                  href={`/kafka/${kafkaId}/consumer-groups/${row.id === "" ? "+" : encodeURIComponent(row.id)}`}
                 >
                   {row.id === "" ? (
                     <i>{t("ConsumerGroupsTable.empty_name")}</i>


### PR DESCRIPTION
As we use the consumer group id as a url fragment, we need to escape it to avoid problematic characters (like .) 
Fixes #633 