### PR TITLE
Change the required env variables

### DIFF
--- a/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.tsx
@@ -25,24 +25,24 @@ import { useState } from "react";
 export function DistributionChart({
   data,
 }: {
-  data: Record<string, { leaders: number; followers: number }>;
+  data: Record<string, { leaders?: number; followers?: number }>;
 }) {
   const t = useTranslations();
   const [containerRef, width] = useChartWidth();
   const [filter, setFilter] = useState<"all" | "leaders" | "followers">("all");
   const allCount = Object.values(data).reduce(
-    (acc, v) => v.followers + v.leaders + acc,
+    (acc, v) => (v.followers ?? 0) + (v.leaders ?? 0) + acc,
     0,
   );
   const leadersCount = Object.values(data).reduce(
-    (acc, v) => v.leaders + acc,
+    (acc, v) => (v.leaders ?? 0) + acc,
     0,
   );
   const followersCount = Object.values(data).reduce(
-    (acc, v) => v.followers + acc,
+    (acc, v) => (v.followers ?? 0) + acc,
     0,
   );
-  return (
+  return allCount > 0 ? (
     <Card className={"pf-v5-u-mb-lg"}>
       <CardHeader>
         <CardTitle>
@@ -172,7 +172,7 @@ export function DistributionChart({
                       name: `Broker ${node}`,
                       x: "x",
                       y: {
-                        all: data.leaders + data.followers,
+                        all: (data.leaders ?? 0) + (data.followers ?? 0),
                         leaders: data.leaders,
                         followers: data.followers,
                       }[filter || "all"],
@@ -185,5 +185,5 @@ export function DistributionChart({
         </div>
       </CardBody>
     </Card>
-  );
+  ) : null;
 }

--- a/ui/app/[locale]/kafka/[kafkaId]/nodes/NodesTable.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/nodes/NodesTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Number } from "@/components/Format/Number";
 import { ResponsiveTable } from "@/components/Table";
 import {
   ChartDonutThreshold,
@@ -29,12 +30,12 @@ export type Node = {
   id: number;
   isLeader: boolean;
   status: string;
-  followers: number;
-  leaders: number;
+  followers?: number;
+  leaders?: number;
   rack?: string;
   hostname?: string;
-  diskCapacity: number;
-  diskUsage: number;
+  diskCapacity?: number;
+  diskUsage?: number;
 };
 
 export function NodesTable({ nodes }: { nodes: Node[] }) {
@@ -109,7 +110,13 @@ export function NodesTable({ nodes }: { nodes: Node[] }) {
           case "replicas":
             return (
               <Td key={key} dataLabel={"Total replicas"}>
-                {row.followers + row.leaders}
+                <Number
+                  value={
+                    row.followers && row.leaders
+                      ? row.followers + row.leaders
+                      : undefined
+                  }
+                />
               </Td>
             );
           case "rack":
@@ -147,49 +154,55 @@ export function NodesTable({ nodes }: { nodes: Node[] }) {
                 </Text>
               </TextContent>
               <div style={{ width: 350, height: 200 }}>
-                <ChartDonutThreshold
-                  ariaDesc="Storage capacity"
-                  ariaTitle={`Broker ${row.id} disk usage`}
-                  constrainToVisibleArea={true}
-                  data={[
-                    { x: "Warning at 60%", y: 60 },
-                    { x: "Danger at 90%", y: 90 },
-                  ]}
-                  height={200}
-                  labels={({ datum }) => (datum.x ? datum.x : null)}
-                  padding={{
-                    bottom: 0,
-                    left: 10,
-                    right: 150,
-                    top: 0,
-                  }}
-                  width={350}
-                >
-                  <ChartDonutUtilization
-                    data={{
-                      x: "Storage capacity",
-                      y: (row.diskUsage / row.diskCapacity) * 100,
-                    }}
-                    labels={({ datum }) =>
-                      datum.x
-                        ? `${datum.x}: ${format.number(datum.y / 100, {
+                {row.diskUsage !== undefined &&
+                  row.diskCapacity !== undefined && (
+                    <ChartDonutThreshold
+                      ariaDesc="Storage capacity"
+                      ariaTitle={`Broker ${row.id} disk usage`}
+                      constrainToVisibleArea={true}
+                      data={[
+                        { x: "Warning at 60%", y: 60 },
+                        { x: "Danger at 90%", y: 90 },
+                      ]}
+                      height={200}
+                      labels={({ datum }) => (datum.x ? datum.x : null)}
+                      padding={{
+                        bottom: 0,
+                        left: 10,
+                        right: 150,
+                        top: 0,
+                      }}
+                      width={350}
+                    >
+                      <ChartDonutUtilization
+                        data={{
+                          x: "Storage capacity",
+                          y: (row.diskUsage / row.diskCapacity) * 100,
+                        }}
+                        labels={({ datum }) =>
+                          datum.x
+                            ? `${datum.x}: ${format.number(datum.y / 100, {
+                                style: "percent",
+                              })}`
+                            : null
+                        }
+                        legendData={[
+                          { name: `Capacity: 80%` },
+                          { name: "Warning at 60%" },
+                          { name: "Danger at 90%" },
+                        ]}
+                        legendOrientation="vertical"
+                        title={`${format.number(
+                          row.diskUsage / row.diskCapacity,
+                          {
                             style: "percent",
-                          })}`
-                        : null
-                    }
-                    legendData={[
-                      { name: `Capacity: 80%` },
-                      { name: "Warning at 60%" },
-                      { name: "Danger at 90%" },
-                    ]}
-                    legendOrientation="vertical"
-                    title={`${format.number(row.diskUsage / row.diskCapacity, {
-                      style: "percent",
-                    })}`}
-                    subTitle={`of ${formatBytes(row.diskCapacity)}`}
-                    thresholds={[{ value: 60 }, { value: 90 }]}
-                  />
-                </ChartDonutThreshold>
+                          },
+                        )}`}
+                        subTitle={`of ${formatBytes(row.diskCapacity)}`}
+                        thresholds={[{ value: 60 }, { value: 90 }]}
+                      />
+                    </ChartDonutThreshold>
+                  )}
               </div>
             </FlexItem>
           </Flex>

--- a/ui/app/[locale]/kafka/[kafkaId]/nodes/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/nodes/page.tsx
@@ -5,30 +5,53 @@ import {
   Node,
   NodesTable,
 } from "@/app/[locale]/kafka/[kafkaId]/nodes/NodesTable";
-import { PageSection } from "@/libs/patternfly/react-core";
+import { Alert, PageSection } from "@/libs/patternfly/react-core";
 import { redirect } from "@/navigation";
+import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
-function nodeMetric(metrics: Record<string, number> | undefined, nodeId: number): number {
-    return metrics ? (metrics[nodeId.toString()] ?? 0) : 0;
+function nodeMetric(
+  metrics: Record<string, number> | undefined,
+  nodeId: number,
+): number {
+  return metrics ? metrics[nodeId.toString()] ?? 0 : 0;
 }
 
-export default async function NodesPage({ params }: { params: KafkaParams }) {
+export default function NodesPage({ params }: { params: KafkaParams }) {
+  return (
+    <Suspense fallback={null}>
+      <ConnectedNodes params={params} />
+    </Suspense>
+  );
+}
+
+async function ConnectedNodes({ params }: { params: KafkaParams }) {
+  const t = await getTranslations();
   const res = await getKafkaClusterKpis(params.kafkaId);
   if (!res) {
     return redirect("/");
   }
   const { cluster, kpis } = res;
-  if (!cluster) {
-    redirect("/");
-    return null;
-  }
 
   const nodes: Node[] = cluster.attributes.nodes.map((node) => {
-    const status = nodeMetric(kpis.broker_state, node.id) === 3 ? "Stable" : "Unstable";
-    const leaders = nodeMetric(kpis.leader_count?.byNode, node.id);
-    const followers = nodeMetric(kpis.replica_count?.byNode, node.id) - leaders;
-    const diskCapacity = nodeMetric(kpis.volume_stats_capacity_bytes?.byNode, node.id);
-    const diskUsage = nodeMetric(kpis.volume_stats_used_bytes?.byNode, node.id);
+    const status = kpis
+      ? nodeMetric(kpis.broker_state, node.id) === 3
+        ? "Stable"
+        : "Unstable"
+      : "Unknown";
+    const leaders = kpis
+      ? nodeMetric(kpis.leader_count?.byNode, node.id)
+      : undefined;
+    const followers =
+      kpis && leaders
+        ? nodeMetric(kpis.replica_count?.byNode, node.id) - leaders
+        : undefined;
+    const diskCapacity = kpis
+      ? nodeMetric(kpis.volume_stats_capacity_bytes?.byNode, node.id)
+      : undefined;
+    const diskUsage = kpis
+      ? nodeMetric(kpis.volume_stats_used_bytes?.byNode, node.id)
+      : undefined;
     return {
       id: node.id,
       status,
@@ -50,6 +73,12 @@ export default async function NodesPage({ params }: { params: KafkaParams }) {
 
   return (
     <>
+      {!kpis && (
+        <PageSection>
+          <Alert title={t("nodes.kpis_offline")} variant={"warning"} />
+        </PageSection>
+      )}
+
       <PageSection isFilled>
         <DistributionChart data={data} />
         <NodesTable nodes={nodes} />

--- a/ui/app/[locale]/kafka/[kafkaId]/overview/page.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/overview/page.tsx
@@ -44,10 +44,24 @@ async function ConnectedClusterCard({
   data,
   consumerGroups,
 }: {
-  data: Promise<{ cluster: ClusterDetail; kpis: ClusterKpis } | null>;
+  data: Promise<{ cluster: ClusterDetail; kpis: ClusterKpis | null } | null>;
   consumerGroups: Promise<ConsumerGroupsResponse>;
 }) {
   const res = await data;
+  if (!res?.kpis) {
+    return (
+      <ClusterCard
+        isLoading={false}
+        status={res?.cluster.attributes.status || "n/a"}
+        messages={[]}
+        name={res?.cluster.attributes.name || "n/a"}
+        consumerGroups={undefined}
+        brokersOnline={undefined}
+        brokersTotal={undefined}
+        kafkaVersion={res?.cluster.attributes.kafkaVersion || "n/a"}
+      />
+    );
+  }
   const groupCount = await consumerGroups.then(
     (grpResp) => grpResp.meta.page.total ?? 0,
   );
@@ -86,9 +100,12 @@ async function ConnectedClusterCard({
 async function ConnectedTopicsPartitionsCard({
   data,
 }: {
-  data: Promise<{ cluster: ClusterDetail; kpis: ClusterKpis } | null>;
+  data: Promise<{ cluster: ClusterDetail; kpis: ClusterKpis | null } | null>;
 }) {
   const res = await data;
+  if (!res?.kpis) {
+    return null;
+  }
   const topicsTotal = res?.kpis.total_topics || 0;
   const topicsUnderreplicated = res?.kpis.underreplicated_topics || 0;
   return (

--- a/ui/components/ClusterOverview/ClusterCard.tsx
+++ b/ui/components/ClusterOverview/ClusterCard.tsx
@@ -33,9 +33,9 @@ import { ErrorsAndWarnings } from "./components/ErrorsAndWarnings";
 type ClusterCardProps = {
   name: string;
   status: string;
-  brokersOnline: number;
-  brokersTotal: number;
-  consumerGroups: number;
+  brokersOnline?: number;
+  brokersTotal?: number;
+  consumerGroups?: number;
   kafkaVersion: string;
   messages: Array<{
     variant: "danger" | "warning";

--- a/ui/environment.d.ts
+++ b/ui/environment.d.ts
@@ -2,13 +2,12 @@ namespace NodeJS {
   interface ProcessEnv {
     NEXTAUTH_URL: string;
     NEXTAUTH_SECRET: string;
-    SESSION_SECRET: string;
     BACKEND_URL: string;
-    KEYCLOAK_CLIENTID: string;
-    KEYCLOAK_CLIENTSECRET: string;
-    NEXT_PUBLIC_KEYCLOAK_URL: string;
-    CONSOLE_METRICS_PROMETHEUS_URL: string;
-    LOG_LEVEL: "fatal" | "error" | "warn" | "info" | "debug" | "trace";
-    CONSOLE_MODE: "read-only" | "read-write";
+    KEYCLOAK_CLIENTID?: string;
+    KEYCLOAK_CLIENTSECRET?: string;
+    NEXT_PUBLIC_KEYCLOAK_URL?: string;
+    CONSOLE_METRICS_PROMETHEUS_URL?: string;
+    LOG_LEVEL?: "fatal" | "error" | "warn" | "info" | "debug" | "trace";
+    CONSOLE_MODE?: "read-only" | "read-write";
   }
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -23,6 +23,9 @@
   "overview": {
     "title": "Overview"
   },
+  "nodes": {
+    "kpis_offline": "Prometheus can't be reached, information on the page will be incomplete. Please check your configuration."
+  },
   "node-config-table": {
     "no_results_title": "No properties found",
     "no_results_body": "Adjust your selection criteria and try again.",

--- a/ui/utils/authOptions.ts
+++ b/ui/utils/authOptions.ts
@@ -1,31 +1,31 @@
 import { keycloak, refreshToken } from "@/app/api/auth/[...nextauth]/keycloak";
-import CredentialsProvider from "next-auth/providers/credentials";
 
 import { logger } from "@/utils/logger";
 import NextAuth, { NextAuthOptions, Session } from "next-auth";
 import { JWT } from "next-auth/jwt";
+import CredentialsProvider from "next-auth/providers/credentials";
 
 const log = logger.child({ module: "auth" });
 
 const anonymousProvider = CredentialsProvider({
   // The name to display on the sign in form (e.g. 'Sign in with...')
-  name: 'Anonymous Session',
+  name: "Anonymous Session",
 
-  credentials: { },
+  credentials: {},
 
   async authorize() {
-    return { id: '1', name: 'Anonymous', email: 'anonymous@example.com' };
-  }
+    return { id: "1", name: "Anonymous", email: "anonymous@example.com" };
+  },
 });
 
 let _providers = [];
 let _callbacks = {};
 
-if (keycloak.options?.issuer) {
+if (keycloak && keycloak.options?.issuer) {
   log.debug("Using keycloak provider");
   _providers.push(keycloak);
   _callbacks = {
-    async jwt({ token, account }: { token: JWT, account: any }) {
+    async jwt({ token, account }: { token: JWT; account: any }) {
       // Persist the OAuth access_token and or the user id to the token right after signin
       if (account) {
         log.trace("account present, saving new token");
@@ -43,7 +43,7 @@ if (keycloak.options?.issuer) {
 
       return refreshToken(token);
     },
-    async session({ session, token }: { session: Session, token: JWT }) {
+    async session({ session, token }: { session: Session; token: JWT }) {
       // Send properties to the client, like an access_token from a provider.
       log.trace(token, "Creating session from token");
       return {

--- a/ui/utils/logger.ts
+++ b/ui/utils/logger.ts
@@ -4,7 +4,7 @@ export const logger = pino({
   browser: {
     asObject: true,
   },
-  level: process.env.LOG_LEVEL,
+  level: process.env.LOG_LEVEL ?? "info",
   base: {
     env: process.env.NODE_ENV,
   },

--- a/ui/utils/session.ts
+++ b/ui/utils/session.ts
@@ -1,10 +1,10 @@
 "use server";
 
 import { authOptions } from "@/utils/authOptions";
+import { logger } from "@/utils/logger";
 import { sealData, unsealData } from "iron-session";
 import { getServerSession } from "next-auth";
 import { cookies } from "next/headers";
-import { logger } from "@/utils/logger";
 
 const log = logger.child({ module: "session" });
 
@@ -23,7 +23,7 @@ export async function getSession<T extends Record<string, unknown>>(
   }
   try {
     const rawSession = await unsealData(encryptedSession, {
-      password: process.env.SESSION_SECRET,
+      password: process.env.SESSION_SECRET ?? "strimziconsole",
     });
     return rawSession as T;
   } catch {
@@ -40,7 +40,7 @@ export async function setSession<T extends Record<string, unknown>>(
     throw new Error("Can't set session for unauthenticated users");
   }
   const encryptedSession = await sealData(session, {
-    password: process.env.SESSION_SECRET,
+    password: process.env.SESSION_SECRET ?? "strimziconsole",
   });
 
   cookies().set({


### PR DESCRIPTION
Make some take an implicit default; make Prometheus optional showing fallbacks in the UI

For example, the brokers page will show a warning

<img width="1016" alt="image" src="https://github.com/eyefloaters/console/assets/966316/4e6f53b8-f874-4b1b-ad83-152531775d1b">

The cluster overview page will show placeholders

<img width="1005" alt="image" src="https://github.com/eyefloaters/console/assets/966316/4513942f-9977-4ab4-ac82-aa2cab70922c">
