### PR TITLE
Allow for showing internal topics from the empty state when no topics exist

### DIFF
--- a/ui/components/TopicsTable/TopicsTable.tsx
+++ b/ui/components/TopicsTable/TopicsTable.tsx
@@ -124,6 +124,7 @@ export function TopicsTable({
         <EmptyStateNoTopics
           canCreate={isReadOnly === false}
           createHref={`${baseurl}/create`}
+          onShowHiddenTopics={() => onInternalTopicsChange(true)}
         />
       }
       emptyStateNoResults={

--- a/ui/components/TopicsTable/components/EmptyStateNoTopics.stories.tsx
+++ b/ui/components/TopicsTable/components/EmptyStateNoTopics.stories.tsx
@@ -7,4 +7,11 @@ export default {
 } as Meta<typeof Comp>;
 type Story = StoryObj<typeof Comp>;
 
-export const EmptyStateNoTopics: Story = {};
+export const Default: Story = {};
+
+export const CanCreate: Story = {
+  args: {
+    canCreate: true,
+    createHref: "#/sample",
+  },
+};

--- a/ui/components/TopicsTable/components/EmptyStateNoTopics.tsx
+++ b/ui/components/TopicsTable/components/EmptyStateNoTopics.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "@/components/Navigation/ButtonLink";
 import {
+  Button,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -7,15 +8,17 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
 } from "@/libs/patternfly/react-core";
-import { PlusCircleIcon } from "@patternfly/react-icons";
+import { PlusCircleIcon } from "@/libs/patternfly/react-icons";
 import { useTranslations } from "next-intl";
 
 export function EmptyStateNoTopics({
   canCreate,
   createHref,
+  onShowHiddenTopics,
 }: {
   canCreate: boolean;
   createHref: string;
+  onShowHiddenTopics: () => void;
 }) {
   const t = useTranslations();
   return (
@@ -28,15 +31,18 @@ export function EmptyStateNoTopics({
       <EmptyStateBody>
         {t("EmptyStateNoTopics.to_get_started_create_your_first_topic")}{" "}
       </EmptyStateBody>
-      {canCreate && (
-        <EmptyStateFooter>
-          <EmptyStateActions>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          {canCreate && (
             <ButtonLink variant="primary" href={createHref}>
               {t("EmptyStateNoTopics.create_a_topic")}
             </ButtonLink>
-          </EmptyStateActions>
-        </EmptyStateFooter>
-      )}
+          )}
+          <Button variant="secondary" onClick={onShowHiddenTopics}>
+            {t("EmptyStateNoTopics.show_hidden_topics")}
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
     </EmptyState>
   );
 }

--- a/ui/components/TopicsTable/components/EmptyStateNoTopics.tsx
+++ b/ui/components/TopicsTable/components/EmptyStateNoTopics.tsx
@@ -1,4 +1,5 @@
 import { ButtonLink } from "@/components/Navigation/ButtonLink";
+import { ExternalLink } from "@/components/Navigation/ExternalLink";
 import {
   Button,
   EmptyState,
@@ -41,6 +42,11 @@ export function EmptyStateNoTopics({
           <Button variant="secondary" onClick={onShowHiddenTopics}>
             {t("EmptyStateNoTopics.show_internal_topics")}
           </Button>
+        </EmptyStateActions>
+        <EmptyStateActions>
+          <ExternalLink testId={"create-topic"} href={t("EmptyStateNoTopics.create_topic_external_link")}>
+            {t("EmptyStateNoTopics.view_documentation")}
+          </ExternalLink>
         </EmptyStateActions>
       </EmptyStateFooter>
     </EmptyState>

--- a/ui/components/TopicsTable/components/EmptyStateNoTopics.tsx
+++ b/ui/components/TopicsTable/components/EmptyStateNoTopics.tsx
@@ -39,7 +39,7 @@ export function EmptyStateNoTopics({
             </ButtonLink>
           )}
           <Button variant="secondary" onClick={onShowHiddenTopics}>
-            {t("EmptyStateNoTopics.show_hidden_topics")}
+            {t("EmptyStateNoTopics.show_internal_topics")}
           </Button>
         </EmptyStateActions>
       </EmptyStateFooter>

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -370,7 +370,7 @@
   "EmptyStateNoTopics": {
     "to_get_started_create_your_first_topic": "To get started, create your first topic",
     "create_a_topic": "Create a topic",
-    "show_hidden_topics": "Show hidden topics"
+    "show_internal_topics": "Show internal topics"
   },
   "ApplicationError": {
     "body": "Try clicking the button below, or refreshing the page. If the problem persists, contact your organization administrator.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -371,7 +371,7 @@
     "to_get_started_create_your_first_topic": "To get started, create your first topic",
     "create_a_topic": "Create a topic",
     "show_internal_topics": "Show internal topics",
-    "view_documentation": "Configuring Kafka topics",
+    "view_documentation": "Learn about configuring Kafka topics",
     "create_topic_external_link": "https://docs.redhat.com/en/documentation/red_hat_amq_streams/2.6/html-single/deploying_and_managing_amq_streams_on_openshift/index#proc-configuring-kafka-topic-str"
   },
   "ApplicationError": {

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -370,7 +370,9 @@
   "EmptyStateNoTopics": {
     "to_get_started_create_your_first_topic": "To get started, create your first topic",
     "create_a_topic": "Create a topic",
-    "show_internal_topics": "Show internal topics"
+    "show_internal_topics": "Show internal topics",
+    "view_documentation": "Create topic guide",
+    "create_topic_external_link": "https://docs.redhat.com/en/documentation/red_hat_amq_streams/2.6/html-single/deploying_and_managing_amq_streams_on_openshift/index#proc-configuring-kafka-topic-str"
   },
   "ApplicationError": {
     "body": "Try clicking the button below, or refreshing the page. If the problem persists, contact your organization administrator.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -371,7 +371,7 @@
     "to_get_started_create_your_first_topic": "To get started, create your first topic",
     "create_a_topic": "Create a topic",
     "show_internal_topics": "Show internal topics",
-    "view_documentation": "Create topic guide",
+    "view_documentation": "Configuring Kafka topics",
     "create_topic_external_link": "https://docs.redhat.com/en/documentation/red_hat_amq_streams/2.6/html-single/deploying_and_managing_amq_streams_on_openshift/index#proc-configuring-kafka-topic-str"
   },
   "ApplicationError": {

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -369,7 +369,8 @@
   },
   "EmptyStateNoTopics": {
     "to_get_started_create_your_first_topic": "To get started, create your first topic",
-    "create_a_topic": "Create a topic"
+    "create_a_topic": "Create a topic",
+    "show_hidden_topics": "Show hidden topics"
   },
   "ApplicationError": {
     "body": "Try clicking the button below, or refreshing the page. If the problem persists, contact your organization administrator.",


### PR DESCRIPTION
Fixes #672

## Storybook stories
<img width="1280" alt="image" src="https://github.com/eyefloaters/console/assets/966316/19d4d23f-37b0-4e78-a449-c608781157a2">
<img width="1281" alt="image" src="https://github.com/eyefloaters/console/assets/966316/214fbc38-2787-4eaf-bb70-a0e076e6ab2b">

## In app changes
<img width="1279" alt="image" src="https://github.com/eyefloaters/console/assets/966316/9e615626-72f5-4365-9fd8-3adab66aa9f6">
<img width="1278" alt="image" src="https://github.com/eyefloaters/console/assets/966316/af02521d-566a-481b-9040-e282ac35292d">
