### PR TITLE
Fix typo in the translation file for topic metrics

### DIFF
--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -264,7 +264,7 @@
     "memory_usage_tooltip": "Memory utilization for all brokers over a specified period. Efficient memory allocation is essential for optimal performance of Kafka."
   },
   "topicMetricsCard": {
-     "topic_metric": "Topic Metric",
+     "topic_metric": "Topic metrics",
      "topics_bytes_incoming_and_outgoing": "Topics bytes incoming and outgoing",
      "topics_bytes_incoming_and_outgoing_tooltip": "Bytes incoming and outgoing are the total bytes for all topics or total bytes for a selected topic in the Kafka cluster. This metric enables you to assess data transfer in and out of your Kafka cluster. To modify incoming and outgoing bytes, you can adjust topic message size or other topic properties as needed."
 


### PR DESCRIPTION
Fix typo in the translation file for topic metrics