### PR TITLE
Update Brokers distribution chart legends to show the number/ percentages

### DIFF
--- a/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.stories.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DistributionChart } from "./DistributionChart";
+
+const sampleData = {
+  1: { leaders: 23, followers: 47 },
+  2: { leaders: 24, followers: 46 },
+  3: { leaders: 50, followers: 20 },
+};
+
+const meta: Meta<typeof DistributionChart> = {
+  component: DistributionChart,
+};
+
+export default meta;
+type Story = StoryObj<typeof DistributionChart>;
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+  },
+};

--- a/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.stories.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { DistributionChart } from "./DistributionChart";
 
 const sampleData = {
-  1: { leaders: 23, followers: 47 },
-  2: { leaders: 24, followers: 46 },
-  3: { leaders: 50, followers: 20 },
+  1: { leaders: 20, followers: 80 },
+  2: { leaders: 30, followers: 60 },
+  3: { leaders: 45, followers: 65 },
 };
 
 const meta: Meta<typeof DistributionChart> = {

--- a/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.tsx
@@ -144,8 +144,7 @@ export function DistributionChart({
                 data={Object.keys(data).map((node) => {
                   const count = getCount(data[node]);
                   const percentage = getPercentage(count);
-                  const name = `Broker ${node}: ${count} partitions (${percentage}%)`;
-                  return { name };
+                  return { name: t("DistributionChart.broker_node_count", { node, count, percentage }) };
                 })}
                 itemsPerRow={width > 600 ? 3 : 1}
               />

--- a/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.tsx
+++ b/ui/app/[locale]/kafka/[kafkaId]/nodes/DistributionChart.tsx
@@ -30,6 +30,7 @@ export function DistributionChart({
   const t = useTranslations();
   const [containerRef, width] = useChartWidth();
   const [filter, setFilter] = useState<"all" | "leaders" | "followers">("all");
+
   const allCount = Object.values(data).reduce(
     (acc, v) => (v.followers ?? 0) + (v.leaders ?? 0) + acc,
     0,
@@ -42,6 +43,29 @@ export function DistributionChart({
     (acc, v) => (v.followers ?? 0) + acc,
     0,
   );
+
+  const getCount = (nodeData: { leaders?: number; followers?: number }) => {
+    switch (filter) {
+      case "leaders":
+        return nodeData.leaders ?? 0;
+      case "followers":
+        return nodeData.followers ?? 0;
+      default:
+        return (nodeData.leaders ?? 0) + (nodeData.followers ?? 0);
+    }
+  };
+
+  const getPercentage = (count: number) => {
+    switch (filter) {
+      case "leaders":
+        return ((count / leadersCount) * 100).toFixed(2);
+      case "followers":
+        return ((count / followersCount) * 100).toFixed(2);
+      default:
+        return ((count / allCount) * 100).toFixed(2);
+    }
+  };
+
   return allCount > 0 ? (
     <Card className={"pf-v5-u-mb-lg"}>
       <CardHeader>
@@ -117,30 +141,11 @@ export function DistributionChart({
             legendComponent={
               <ChartLegend
                 orientation={"horizontal"}
-                data={Object.keys(data).flatMap((node) => {
-                  const name = (() => {
-                    switch (filter) {
-                      case "followers":
-                        return t(
-                          "DistributionChart.broker_node_legend_followers",
-                          { node },
-                        );
-                      case "leaders":
-                        return t(
-                          "DistributionChart.broker_node_legend_leaders",
-                          { node },
-                        );
-                      default:
-                        return t("DistributionChart.broker_node_legend_all", {
-                          node,
-                        });
-                    }
-                  })();
-                  return [
-                    {
-                      name,
-                    },
-                  ];
+                data={Object.keys(data).map((node) => {
+                  const count = getCount(data[node]);
+                  const percentage = getPercentage(count);
+                  const name = `Broker ${node}: ${count} partitions (${percentage}%)`;
+                  return { name };
                 })}
                 itemsPerRow={width > 600 ? 3 : 1}
               />
@@ -171,11 +176,7 @@ export function DistributionChart({
                     {
                       name: `Broker ${node}`,
                       x: "x",
-                      y: {
-                        all: (data.leaders ?? 0) + (data.followers ?? 0),
-                        leaders: data.leaders,
-                        followers: data.followers,
-                      }[filter || "all"],
+                      y: getCount(data),
                     },
                   ]}
                 />

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -365,7 +365,8 @@
     "broker_node_legend_followers": "Broker {node} followers",
     "broker_node_voronoi_all": "{name} total partitions: {value}",
     "broker_node_voronoi_leaders": "{name} leaders: {value}",
-    "broker_node_voronoi_followers": "{name} followers: {value}"
+    "broker_node_voronoi_followers": "{name} followers: {value}",
+    "broker_node_count": "Broker {node}: {count} partitions ({percentage}%)"
   },
   "EmptyStateNoTopics": {
     "to_get_started_create_your_first_topic": "To get started, create your first topic",


### PR DESCRIPTION
Update Brokers distribution chart legends to show the number/ percentages
Fixes [issue#359](https://github.com/eyefloaters/console/issues/359) 

storybook story
<img width="1722" alt="Screenshot 2024-05-29 at 3 38 44 PM" src="https://github.com/eyefloaters/console/assets/53568062/858b3c54-654d-467d-91ea-412a6c276223">



