### PR TITLE
Fix test-storybook failing against remote urls

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Test the deployed Storybook
         run: |
           npx playwright install
-          npm run test-storybook -- --url ${{ steps.chromatic.outputs.storybookUrl }}
+          npm run test-storybook -- --no-index-json --url ${{ steps.chromatic.outputs.storybookUrl }}
         working-directory: ./ui


### PR DESCRIPTION
Disabling the JSON index seems to fix the problem

Fixes #785